### PR TITLE
Bugfix: ODBC maximum string length calculation

### DIFF
--- a/oss_src/sframe/odbc_connector.cpp
+++ b/oss_src/sframe/odbc_connector.cpp
@@ -1254,8 +1254,9 @@ std::pair<flexible_type, flexible_type> odbc_connector::get_column_limits(
       case flex_type_enum::INTEGER:
       case flex_type_enum::FLOAT:
       case flex_type_enum::DATETIME:
-      case flex_type_enum::UNDEFINED:
         return false;
+      case flex_type_enum::UNDEFINED:
+        return true;
       //TODO: This probably doesn't work for image types.  I probably have to
       //worry about saving and loading and the size after that and such. You
       //probably shouldn't be loading images into an RDBMS anyways.
@@ -1671,7 +1672,13 @@ void odbc_connector::insert_data_impl(sframe &sf, const std::string &table_name,
         auto cur_elem_size = strified.size()+1;
 
         if(cur_elem_size > m_column_write_info[elem_num].max_size_in_bytes) { 
-          log_and_throw(strified + std::string(" is too big for buffer!"));
+          std::stringstream err_msg;
+          err_msg << "Row " << cur_row << " \"" << strified << "\"" <<
+            " is too big for buffer size of column " << elem_num << " '" <<
+            m_column_write_info[elem_num].column_name << "' (" <<
+            cur_elem_size << " > " <<
+            m_column_write_info[elem_num].max_size_in_bytes << ").";
+          log_and_throw(err_msg.str());
         }
 
         memcpy((char *)m_row_bound_params[elem_num] +

--- a/oss_src/sframe/odbc_connector.cpp
+++ b/oss_src/sframe/odbc_connector.cpp
@@ -990,6 +990,9 @@ void odbc_connector::map_types_for_writing(sframe &sf, bool optimize_db_storage)
       // you an error.
       size_t cnt = 0;
       for(auto it = qk_checker.begin(0); it != qk_checker.end(0); ++it, ++cnt) {
+        if((*it).get_type() != flex_type_enum::DICT) {
+          continue;
+        }
         auto the_dict = (*it).get<flex_dict>();
         auto find_ret = std::find(the_dict.begin(), the_dict.end(),
             std::pair<flexible_type, flexible_type>("_SQL_INTERVAL", 1));


### PR DESCRIPTION
Before writing a table to a SQL database, we must find the max length
for each column to know how much memory to allocate for a row. Our code
to do this for string and image type columns was slightly wrong, as it
stopped calculating the maximum if it ever found a NULL in the column.
So whatever was the maximum so far in that segment was taken to be the
maximum. This caused an infrequent error in certain datasets. Fixed
with this.

Also made an error message a little more clear.