### PR TITLE
Convenience operators for converting between sframe/sarray flavors.

### DIFF
--- a/oss_src/unity/lib/CMakeLists.txt
+++ b/oss_src/unity/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ make_library(unity_core
     unity_odbc_connection.cpp
     image_util.cpp
     ../extensions/additional_sframe_utilities.cpp
+    sframe_sarray_type_conversions.cpp
   REQUIRES
     flexible_type
     pylambda table_printer

--- a/oss_src/unity/lib/gl_sarray.hpp
+++ b/oss_src/unity/lib/gl_sarray.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sframe/sframe_rows.hpp>
 #include <flexible_type/flexible_type.hpp>
+#include "sframe_sarray_type_conversions.hpp"
 
 namespace graphlab {
 /**************************************************************************/

--- a/oss_src/unity/lib/sframe_sarray_type_conversions.cpp
+++ b/oss_src/unity/lib/sframe_sarray_type_conversions.cpp
@@ -1,0 +1,219 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#include <unity/lib/gl_sarray.hpp>
+#include <unity/lib/gl_sframe.hpp>
+#include <unity/lib/unity_sarray.hpp>
+#include <unity/lib/unity_sframe.hpp>
+#include <sframe/sarray.hpp>
+#include <sframe/sframe.hpp>
+
+namespace graphlab { 
+
+/**************************************************************************/
+/*                                                                        */
+/*             Conversion functions                                       */
+/*                                                                        */
+/**************************************************************************/
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(const gl_sarray& g) {
+  std::shared_ptr<unity_sarray> u = g;
+  return u;
+}
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ *  \overload
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(const std::shared_ptr<unity_sarray>& u) {
+  return u;
+}
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ *  \overload
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(
+    const std::shared_ptr<sarray<flexible_type> >& sa) {
+  std::shared_ptr<unity_sarray> u;
+  u->construct_from_sarray(sa);
+  return u;
+}
+
+////////////////////////////////////////
+// To sarray
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(const gl_sarray& g) {
+  return to_sarray(to_unity_sarray(g));
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(const std::shared_ptr<unity_sarray>& g) {
+  return g->get_underlying_sarray();
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(
+    const std::shared_ptr<unity_sarray_base>& g) {
+  return to_sarray(gl_sarray(g));
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(
+    const std::shared_ptr<sarray<flexible_type> >& sa) {
+  return sa;
+}
+
+////////////////////////////////////////
+// To gl_sarray
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<sarray<flexible_type> >& sa) {
+  return gl_sarray(to_unity_sarray(sa));
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<unity_sarray>& g) {
+  return gl_sarray(g);
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<unity_sarray_base>& g) {
+  return gl_sarray(g);
+}
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const gl_sarray& g) { 
+  return g;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Sframe stuff
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const gl_sframe& g) {
+  std::shared_ptr<unity_sframe> u = g;
+  return u;
+}
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ *  \overload
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const std::shared_ptr<unity_sframe>& u) {
+  return u;
+}
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ *  \overload
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const sframe& sf) {
+  std::shared_ptr<unity_sframe> u;
+  u->construct_from_sframe(sf);
+  return u;
+}
+
+////////////////////////////////////////
+// To sframe
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ */
+sframe to_sframe(const gl_sframe& g) {
+  return to_sframe(to_unity_sframe(g));
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const std::shared_ptr<unity_sframe>& g) {
+  return *(g->get_underlying_sframe());
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const std::shared_ptr<unity_sframe_base>& g) {
+  return to_sframe(gl_sframe(g));
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const sframe& sf) {
+  return sf;
+}
+
+////////////////////////////////////////
+// To gl_sframe
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ */
+gl_sframe to_gl_sframe(const sframe& sf) {
+  return gl_sframe(to_unity_sframe(sf));
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const std::shared_ptr<unity_sframe>& g) {
+  return gl_sframe(g);
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const std::shared_ptr<unity_sframe_base>& g) {
+  return gl_sframe(g);
+}
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const gl_sframe& g) { 
+  return g;
+}
+
+
+}

--- a/oss_src/unity/lib/sframe_sarray_type_conversions.hpp
+++ b/oss_src/unity/lib/sframe_sarray_type_conversions.hpp
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#ifndef GRAPHLAB_UNITY_SFRAME_SARRAY_TYPE_CONVERSIONS_H_
+#define GRAPHLAB_UNITY_SFRAME_SARRAY_TYPE_CONVERSIONS_H_
+
+#include <memory>
+
+namespace graphlab { 
+
+class sframe;
+class unity_sframe;
+class unity_sframe_base;
+class gl_sframe;
+
+template <typename T> class sarray;
+class unity_sarray;
+class unity_sarray_base;
+class gl_sarray;
+
+////////////////////////////////////////////////////////////////////////////////
+// Utility functions for conversion to other types.
+
+////////////////////////////////////////
+// To unity_sarray
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(const gl_sarray& g);
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ *  \overload
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(const std::shared_ptr<unity_sarray>& u);
+
+/** Converts a gl_sarray, unity_sarray, or
+ *  sarray<flexible_type> to a unity_sarray.
+ *  \overload
+ */
+std::shared_ptr<unity_sarray> to_unity_sarray(
+    const std::shared_ptr<sarray<flexible_type> >& sa);
+
+////////////////////////////////////////
+// To sarray
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(const gl_sarray& g);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(const std::shared_ptr<unity_sarray>& g);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(
+    const std::shared_ptr<unity_sarray_base>& g);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to an sarray<flexible_type>.
+ * \overload
+ */
+std::shared_ptr<sarray<flexible_type> > to_sarray(
+    const std::shared_ptr<sarray<flexible_type> >& sa);
+
+////////////////////////////////////////
+// To gl_sarray
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<sarray<flexible_type> >& sa);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<unity_sarray>& g);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const std::shared_ptr<unity_sarray_base>& g);
+
+/** Converts a gl_sarray, unity_sarray, unity_sarray_base, or
+ *  sarray<flexible_type> to a gl_sarray
+ * \overload
+ */
+gl_sarray to_gl_sarray(const gl_sarray& g);
+
+////////////////////////////////////////////////////////////////////////////////
+// Sframe stuff
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const gl_sframe& g);
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ *  \overload
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const std::shared_ptr<unity_sframe>& u);
+
+/** Converts a gl_sframe, unity_sframe, or
+ *  sframe<flexible_type> to a unity_sframe.
+ *  \overload
+ */
+std::shared_ptr<unity_sframe> to_unity_sframe(const sframe& sf);
+
+////////////////////////////////////////
+// To sframe
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ */
+sframe to_sframe(const gl_sframe& g);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const std::shared_ptr<unity_sframe>& g);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const std::shared_ptr<unity_sframe_base>& g);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to an sframe.
+ * \overload
+ */
+sframe to_sframe(const sframe& sf);
+
+////////////////////////////////////////
+// To gl_sframe
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ */
+gl_sframe to_gl_sframe(const sframe& sf);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const std::shared_ptr<unity_sframe>& g);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const std::shared_ptr<unity_sframe_base>& g);
+
+/** Converts a gl_sframe, unity_sframe, unity_sframe_base, or
+ *  sframe to a gl_sframe
+ * \overload
+ */
+gl_sframe to_gl_sframe(const gl_sframe& g);
+
+}
+
+#endif /* GRAPHLAB_UNITY_SFRAME_SARRAY_TYPE_CONVERSIONS_H_ */


### PR DESCRIPTION
Added convenience functions to allow converting between any flavor of
(gl_sarray, unity_sarray, sarray) and between any flavor of
(gl_sframe, unity_sframe, sframe).  To use, simply include gl_sarray
or gl_sframe, and then call to_sarray, to_unity_sarray, or
to_gl_sarray, with any of the sarray flavors to get to the appropriate
type. SFrame stuff behaves the same way.