### PR TITLE
Improve logging when launching processes

### DIFF
--- a/oss_src/cppipc/common/object_factory_impl.cpp
+++ b/oss_src/cppipc/common/object_factory_impl.cpp
@@ -10,13 +10,13 @@
 
 namespace cppipc {
 size_t object_factory_impl::make_object(std::string object_type_name) {
-  std::cerr << "Creating object of type : "<< object_type_name << "\n";
+  std::cout << "Creating object of type : "<< object_type_name << "\n";
   std::shared_ptr<void> ptr;
   if (constructors.count(object_type_name)) ptr = constructors[object_type_name]();
   if (ptr) {
     // register in the server
     size_t id = srv.register_object(ptr);
-    std::cerr << "New object with id " << id << " registered\n";
+    std::cout << "New object with id " << id << " registered\n";
     return id;
   } else {
     return (size_t)(-1);
@@ -43,7 +43,7 @@ std::string object_factory_impl::ping(std::string pingval) {
 }
 
 void object_factory_impl::delete_object(size_t object_id) {
-  std::cerr << "Deleting Object : " << object_id << "\n";
+  std::cout << "Deleting Object : " << object_id << "\n";
   srv.delete_object(object_id);
 }
 

--- a/oss_src/lambda/worker_pool.hpp
+++ b/oss_src/lambda/worker_pool.hpp
@@ -70,7 +70,7 @@ std::shared_ptr<worker_connection<ProxyType>> spawn_worker(std::string worker_bi
       } else {
         // Connecting to server failed
         logstream(LOG_ERROR) << "Fail connecting to worker at " << worker_address
-          << ". Status: " << cppipc::reply_status_to_string(status)
+          << ". Status: " << cppipc::reply_status_to_string(status) 
           << ". Retry: " << retry << std::endl;
         logstream(LOG_ERROR) << "Stderr output from worker: " << worker_proc->read_from_child() << std::endl;
       }
@@ -87,6 +87,7 @@ std::shared_ptr<worker_connection<ProxyType>> spawn_worker(std::string worker_bi
   if (!success) {
     throw std::string("Fail launching lambda worker.");
   } else {
+    worker_proc->close_read_pipe();
     return std::make_shared<worker_connection<ProxyType>>(worker_proc, worker_address, cli);
   }
 }

--- a/oss_src/logger/log_rotate.cpp
+++ b/oss_src/logger/log_rotate.cpp
@@ -79,7 +79,7 @@ void begin_log_rotation(std::string _log_file_name,
   symlink_name = log_base_name;
 
   thread_running = true;
-  std::cerr << "Launching log rotate thread" << std::endl;
+  std::cout << "Launching log rotate thread" << std::endl;
   log_rotate_thread.launch(log_rotation_background_thread);
 }
 

--- a/oss_src/logger/logger.cpp
+++ b/oss_src/logger/logger.cpp
@@ -259,7 +259,11 @@ void file_logger::_lograw(int lineloglevel, const char* buf, int len) {
       textcolor(stderr, BRIGHT, GREEN);
     }
 #endif
-    std::cerr.write(buf,len);
+    if(lineloglevel >= LOG_WARNING) {
+      std::cerr.write(buf,len);
+    } else {
+      std::cout.write(buf,len);
+    }
 #ifdef COLOROUTPUT
 
     pthread_mutex_unlock(&mut);

--- a/oss_src/process/CMakeLists.txt
+++ b/oss_src/process/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 make_library(process
   SOURCES
+    process.cpp
     ${PLATFORM_SOURCES}
   REQUIRES
     util

--- a/oss_src/process/process.cpp
+++ b/oss_src/process/process.cpp
@@ -1,0 +1,25 @@
+#include <process/process.hpp>
+#include <logger/logger.hpp>
+
+namespace graphlab {
+
+std::string process::read_from_child() {
+  const size_t BUF_SIZE = 4096;
+  char buf[BUF_SIZE];
+  ssize_t bytes_read;
+  std::stringstream msg;
+  while( (bytes_read = read_from_child(buf, BUF_SIZE)) > 0 ) {
+    msg << std::string(buf, buf + bytes_read);
+  }
+
+  std::string ret = msg.str();
+  if(bytes_read == -1) {
+    logstream(LOG_WARNING) <<
+      "Error reading from child, message may be partial " << "(" <<
+      ret.size() << " bytes received)." << std::endl;
+  }
+
+  return ret;
+}
+
+} // namespace graphlab

--- a/oss_src/process/process.hpp
+++ b/oss_src/process/process.hpp
@@ -73,6 +73,7 @@ class process {
    */
   ssize_t read_from_child(void *buf, size_t count);
 
+  std::string read_from_child();
   /**
    * Kill the launched process
    *

--- a/oss_src/process/process.hpp
+++ b/oss_src/process/process.hpp
@@ -96,6 +96,8 @@ class process {
    */
   int get_return_code();
 
+  void close_read_pipe();
+
   size_t get_pid();
 
   /**

--- a/oss_src/process/process_unix.cpp
+++ b/oss_src/process/process_unix.cpp
@@ -119,11 +119,14 @@ bool process::popen(const std::string &cmd,
     return false;
   } else if(pid == 0) {
     //***In child***
-    if(child_write_fd > -1) {
-      dup2(write_fd, child_write_fd);
-    }
-    close(write_fd);
     close(read_fd);
+    if((child_write_fd > -1) && (write_fd != child_write_fd)) {
+      errno = 0;
+      if(dup2(write_fd, child_write_fd) != child_write_fd) {
+        logstream(LOG_ERROR) << "dup2 failed to duplicate fd!" << strerror(errno) << std::endl;
+      }
+      close(write_fd);
+    }
 
     int exec_ret = execvp(&cmd[0], (char**)c_arglist);
     if(exec_ret == -1) {
@@ -247,8 +250,10 @@ void process::close_read_pipe() {
     log_and_throw("Cannot close pipe from process when launched without a pipe!");
   if(m_read_handle == -1)
     log_and_throw("Cannot close pipe from child, no pipe initialized.");
-  close(m_read_handle);
-  m_read_handle = -1;
+  if(m_read_handle > -1) {
+    close(m_read_handle);
+    m_read_handle = -1;
+  }
 }
 
 size_t process::get_pid() {

--- a/oss_src/process/process_unix.cpp
+++ b/oss_src/process/process_unix.cpp
@@ -123,7 +123,7 @@ bool process::popen(const std::string &cmd,
     if((child_write_fd > -1) && (write_fd != child_write_fd)) {
       errno = 0;
       if(dup2(write_fd, child_write_fd) != child_write_fd) {
-        logstream(LOG_ERROR) << "dup2 failed to duplicate fd!" << strerror(errno) << std::endl;
+        _exit(1);
       }
       close(write_fd);
     }

--- a/oss_src/process/process_unix.cpp
+++ b/oss_src/process/process_unix.cpp
@@ -240,6 +240,17 @@ int process::get_return_code() {
   return WEXITSTATUS(status);
 }
 
+void process::close_read_pipe() {
+  if(!m_launched)
+    log_and_throw("No process launched!");
+  if(!m_launched_with_popen)
+    log_and_throw("Cannot close pipe from process when launched without a pipe!");
+  if(m_read_handle == -1)
+    log_and_throw("Cannot close pipe from child, no pipe initialized.");
+  close(m_read_handle);
+  m_read_handle = -1;
+}
+
 size_t process::get_pid() {
   return size_t(m_pid);
 }

--- a/oss_src/process/process_win.cpp
+++ b/oss_src/process/process_win.cpp
@@ -192,7 +192,7 @@ ssize_t process::read_from_child(void *buf, size_t count) {
   DWORD bytes_read;
   BOOL ret = ReadFile(m_read_handle, (LPWORD)buf, count, &bytes_read, NULL);
   if(!ret) {
-    logstream(LOG_INFO) << "ReadFile failed: " <<
+    logstream(LOG_ERROR) << "ReadFile failed: " <<
       get_last_err_str(GetLastError()) << std::endl;
   }
 

--- a/oss_src/process/process_win.cpp
+++ b/oss_src/process/process_win.cpp
@@ -199,6 +199,15 @@ ssize_t process::read_from_child(void *buf, size_t count) {
   return ret ? ssize_t(bytes_read) : ssize_t(-1);
 }
 
+void process::close_read_pipe() {
+  if(!m_launched)
+    log_and_throw("No process launched!");
+  if(!m_launched_with_popen || m_read_handle == NULL)
+    log_and_throw("Cannot close read pipe from child, no pipe initialized.");
+  CloseHandle(m_read_handle);
+  m_read_handle = NULL;
+}
+
 bool process::kill(bool async) {
   if(!m_launched)
     log_and_throw("No process launched!");

--- a/oss_src/unity/python/sframe/__init__.py
+++ b/oss_src/unity/python/sframe/__init__.py
@@ -57,6 +57,7 @@ version = '{{VERSION_STRING}}'
 
 from .util import get_environment_config
 from .util import get_graphlab_object_type
+from .util import get_log_location, get_client_log_location, get_server_log_location
 
 from .version_info import version
 from .version_info import __VERSION__

--- a/oss_src/unity/python/sframe/connect/server.py
+++ b/oss_src/unity/python/sframe/connect/server.py
@@ -155,12 +155,12 @@ class LocalServer(GraphLabServer):
                 self.proc = subprocess.Popen(arglist,
                         env=_sys_util.make_unity_server_env(),
                         stdin=subprocess.PIPE, stdout=FNULL,
-                        stderr=subprocess.STDOUT, bufsize=-1) # preexec_fn not supported on windows
+                        stderr=sys.stderr, bufsize=-1) # preexec_fn not supported on windows
             else:
                 self.proc = subprocess.Popen(arglist,
                         env=_sys_util.make_unity_server_env(),
                         stdin=subprocess.PIPE, stdout=FNULL,
-                        stderr=subprocess.STDOUT, bufsize=-1,
+                        stderr=sys.stderr, bufsize=-1,
                         preexec_fn=lambda: os.setpgrp())  # do not forward signal
         except OSError as e:
             raise RuntimeError('Invalid server binary \"%s\": %s' % (self.server_bin, str(e)))

--- a/oss_src/unity/python/sframe/connect/server.py
+++ b/oss_src/unity/python/sframe/connect/server.py
@@ -155,12 +155,12 @@ class LocalServer(GraphLabServer):
                 self.proc = subprocess.Popen(arglist,
                         env=_sys_util.make_unity_server_env(),
                         stdin=subprocess.PIPE, stdout=FNULL,
-                        stderr=sys.stderr, bufsize=-1) # preexec_fn not supported on windows
+                        stderr=None, bufsize=-1) # preexec_fn not supported on windows
             else:
                 self.proc = subprocess.Popen(arglist,
                         env=_sys_util.make_unity_server_env(),
                         stdin=subprocess.PIPE, stdout=FNULL,
-                        stderr=sys.stderr, bufsize=-1,
+                        stderr=None, bufsize=-1,
                         preexec_fn=lambda: os.setpgrp())  # do not forward signal
         except OSError as e:
             raise RuntimeError('Invalid server binary \"%s\": %s' % (self.server_bin, str(e)))

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -800,3 +800,16 @@ def _raise_error_if_not_function(arg, arg_name=None):
     if not hasattr(arg, '__call__'):
       raise TypeError, err_msg
 
+def get_log_location():
+    from ..connect import main as _glconnect
+    server = _glconnect.get_server()
+    if hasattr(server, 'unity_log'):
+        return server.unity_log
+    else:
+        return None
+
+def get_client_log_location():
+    return client_log_file
+
+def get_server_log_location():
+    return get_log_location()

--- a/oss_src/unity/server/unity_server.cpp
+++ b/oss_src/unity/server/unity_server.cpp
@@ -159,6 +159,18 @@ int main(int argc, char** argv) {
   }
 #endif
 
+#ifdef _WIN32
+  // Make sure dialog boxes don't come up for errors (apparently doesn't affect
+  // "hard system errors")
+  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+
+  // Don't listen to ctrl-c.  On Windows, a ctrl-c is delivered to every
+  // application "sharing" the console that is selected with the mouse. This
+  // causes unity_server to crash even though the client handles it correctly,
+  // unless we disable ctrl-c events.
+  SetConsoleCtrlHandler(NULL, true);
+#endif
+
   graphlab::configure_global_environment(argv[0]);
 
   std::string program_name = argv[0];


### PR DESCRIPTION
When launching a process (unity_server or pylambda_worker in this
commit) make sure that if the process errors out, the error message is
delivered to the user in some form (either to terminal or log). Also
some commands in the top namespace to print the location of the log to
look for errors.

Testing was in the form of manual adversarial tests, as it involved
breaking a current installation by moving files around, or changing
other system stuff.