### PR TITLE
Update _internal_utils.py

### DIFF
--- a/oss_src/unity/python/sframe/toolkits/_internal_utils.py
+++ b/oss_src/unity/python/sframe/toolkits/_internal_utils.py
@@ -321,7 +321,7 @@ def _check_categorical_option_type(option_name, option_value, possible_values):
     err_msg = '{0} is not a valid option for {0}. '.format(option_value, option_name)
     err_msg += ' Expected one of: '.format(possible_values)
 
-    err_msg += ', '.join(possible_values)
+    err_msg += ', '.join(map(str, possible_values))
     if option_value not in possible_values:
         raise ToolkitError, err_msg
 


### PR DESCRIPTION
Fixed an issue with the internal utils where checks failed when you add a "None" in the list. This happens because we assume that all the elements in the list are string, but they aren't.