### PR TITLE
ODBC Fix

### DIFF
--- a/oss_src/unity/python/sframe/data_structures/DBConnection.py
+++ b/oss_src/unity/python/sframe/data_structures/DBConnection.py
@@ -5,8 +5,6 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 '''
-from .. import extensions, set_runtime_config, get_runtime_config
-from .. import connect as _mt
 
 def connect_odbc(conn_str):
     """
@@ -30,6 +28,8 @@ def connect_odbc(conn_str):
     --------
     >>> db = graphlab.connect_odbc("DSN=my_awesome_dsn;UID=user;PWD=mypassword")
     """
+    from .. import extensions
+    from .. import connect as _mt
     db = extensions._odbc_connection.unity_odbc_connection()
     db._construct_from_odbc_conn_str(conn_str)
     _mt._get_metric_tracker().track('connect_odbc', properties={'dbms_name':db.dbms_name,'dbms_version':db.dbms_version})
@@ -45,11 +45,13 @@ def set_libodbc_path(path):
     if you installed your driver manager in a standard way, you shouldn't need
     to worry about this function.
     """
+    from .. import set_runtime_config
     set_runtime_config('GRAPHLAB_LIBODBC_PREFIX', path)
 
 def get_libodbc_path():
     """
     Get the first path that GraphLab Create will search for libodbc.so.
     """
+    from .. import set_runtime_config
     c = get_runtime_config()
     return c['GRAPHLAB_LIBODBC_PREFIX']

--- a/oss_src/unity/python/sframe/toolkits/_model.py
+++ b/oss_src/unity/python/sframe/toolkits/_model.py
@@ -9,7 +9,6 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 '''
-from .. import extensions as _extensions
 from .. import connect as _mt
 from ..connect import main as glconnect
 from ..data_structures.sframe import SFrame as _SFrame
@@ -151,6 +150,7 @@ def _get_default_options_wrapper(unity_server_model_name,
           >>> out_sframe = graphlab.{module_name}.get_default_options('json')
         """
         _mt._get_metric_tracker().track('toolkit.%s.get_default_options' % module_name)
+        from .. import extensions as _extensions
         if sdk_model:
             response = _extensions._toolkits_sdk_get_default_options(
                                                           unity_server_model_name)


### PR DESCRIPTION
Fixes the issue that
```
import sframe as sf
sf.connect_odbc(...) # fails

sf.SArray()
sf.connect_odbc(...) # works
```

Normally any use of SFrame.extensions will activate all the extension loading.
However, in this case somehow SFrame.extensions failed to load if it was
imported too early. Might have something to do with the change to relative
imports.

Fixes #19