### PR TITLE
Ssl certificate issues

### DIFF
--- a/oss_local_scripts/pip_requirements.txt
+++ b/oss_local_scripts/pip_requirements.txt
@@ -12,3 +12,4 @@ Flask-Cors==1.10.3
 Flask-RESTful==0.3.0
 multipledispatch>=0.4.7
 wheel==0.24.0
+certifi==2015.04.28

--- a/oss_src/fileio/dmlcio/s3_filesys.cc
+++ b/oss_src/fileio/dmlcio/s3_filesys.cc
@@ -378,7 +378,6 @@ void CURLReadStreamBase::Init(size_t begin_bytes) {
   ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_HEADERDATA, &header_) == CURLE_OK);
   SetSSLCertificates(ecurl_);
   curl_easy_setopt(ecurl_, CURLOPT_NOSIGNAL, 1);
-  curl_easy_setopt(ecurl_, CURLOPT_VERBOSE, 1);
   mcurl_ = curl_multi_init();
   ASSERT_TRUE(curl_multi_add_handle(mcurl_, ecurl_) == CURLM_OK);
   int nrun;

--- a/oss_src/fileio/fileio_constants.cpp
+++ b/oss_src/fileio/fileio_constants.cpp
@@ -149,11 +149,11 @@ EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "/etc/pki/tls/certs/ca-bun
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_FILE, true);
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_DIR, true);
 
-std::string get_alternative_ssl_cert_dir() {
+const std::string& get_alternative_ssl_cert_dir() {
   return FILEIO_ALTERNATIVE_SSL_CERT_DIR;
 }
 
-std::string get_alternative_ssl_cert_file() {
+const std::string& get_alternative_ssl_cert_file() {
   return FILEIO_ALTERNATIVE_SSL_CERT_FILE;
 }
 

--- a/oss_src/fileio/fileio_constants.cpp
+++ b/oss_src/fileio/fileio_constants.cpp
@@ -144,8 +144,13 @@ std::string get_cache_file_hdfs_location() {
 }
 
 // Default SSL location for RHEL and FEDORA
+#ifdef __linux__
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_DIR = "/etc/pki/tls/certs";
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "/etc/pki/tls/certs/ca-bundle.crt";
+#else
+EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_DIR = "";
+EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "";
+#endif
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_FILE, true);
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_DIR, true);
 

--- a/oss_src/fileio/fileio_constants.hpp
+++ b/oss_src/fileio/fileio_constants.hpp
@@ -70,8 +70,8 @@ extern size_t FILEIO_WRITER_BUFFER_SIZE;
 /**
  * The alternative ssl certificate file and directory.
  */
-std::string get_alternative_ssl_cert_dir();
-std::string get_alternative_ssl_cert_file();
+const std::string& get_alternative_ssl_cert_dir();
+const std::string& get_alternative_ssl_cert_file();
 
 }
 }

--- a/oss_src/fileio/oss_webstor/wsconn.cpp
+++ b/oss_src/fileio/oss_webstor/wsconn.cpp
@@ -300,9 +300,9 @@ addDefaultCACerts( CURL * curl, void * sslctx, void * parm ) // nofail
 
     // If the user set the runtime config for ssl certificates,
     // we tell SSL to use it as the verify location.
-    const char* alterantive_ssl_cert_file = graphlab::fileio::get_alternative_ssl_cert_dir().c_str();
-    const char* alterantive_ssl_cert_dir = graphlab::fileio::get_alternative_ssl_cert_file().c_str();
-    SSL_CTX_load_verify_locations(reinterpret_cast< SSL_CTX * >( sslctx ), alterantive_ssl_cert_file, alterantive_ssl_cert_dir);
+    const char* alternative_ssl_cert_file = graphlab::fileio::get_alternative_ssl_cert_dir().c_str();
+    const char* alternative_ssl_cert_dir = graphlab::fileio::get_alternative_ssl_cert_file().c_str();
+    SSL_CTX_load_verify_locations(reinterpret_cast< SSL_CTX * >( sslctx ), alternative_ssl_cert_file, alternative_ssl_cert_dir);
 
     for ( const char **p = getDefaultCACerts(); *p != NULL; ++p ) 
     {

--- a/oss_src/fileio/s3_api.cpp
+++ b/oss_src/fileio/s3_api.cpp
@@ -456,9 +456,6 @@ list_objects_response list_objects_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-#ifdef _WIN32
-  config.sslCertFile = "none";
-#endif
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -611,9 +608,6 @@ std::string delete_object_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-#ifdef _WIN32
-  config.sslCertFile = "none";
-#endif
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -645,9 +639,6 @@ std::string delete_prefix_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-#ifdef _WIN32
-  config.sslCertFile = "none";
-#endif
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));

--- a/oss_src/unity/python/setup.py
+++ b/oss_src/unity/python/setup.py
@@ -172,6 +172,7 @@ if __name__ == '__main__':
             "prettytable == 0.7.2",
             "requests == 2.3.0",
             "awscli == 1.6.2",
-            "multipledispatch>=0.4.7"
+            "multipledispatch>=0.4.7",
+            "certifi==2015.04.28" # we need to downgrade certifi to work with S3
         ],
     )

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -65,6 +65,12 @@ def make_unity_server_env():
 
     ## set local to be c standard so that unity_server will run ##
     env['LC_ALL']='C'
+    # add certificate file
+    try:
+        import certifi
+        env['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE'] = certifi.where()
+    except:
+        pass
     return env
 
 

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -66,11 +66,12 @@ def make_unity_server_env():
     ## set local to be c standard so that unity_server will run ##
     env['LC_ALL']='C'
     # add certificate file
-    try:
-        import certifi
-        env['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE'] = certifi.where()
-    except:
-        pass
+    if 'GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE' not in env:
+        try:
+            import certifi
+            env['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE'] = certifi.where()
+        except:
+            pass
     return env
 
 


### PR DESCRIPTION
Fixes several SSL Certificate issues.
 - Made all CURL calls use Python's Certifi store. This allows us to unify: i.e. if awscli works, we should work too. 
 - Switch the DMLCIO S3 block reader to use https
 - Added better error reporting from DMLCIO S3 block reader so we know when there is a certificate validation problem.
 - Enable SSL certificate check in Windows