### PR TITLE
Remove unrecognized kwarg from s3_recursive_delete

### DIFF
--- a/oss_src/unity/python/sframe/_gl_pickle.py
+++ b/oss_src/unity/python/sframe/_gl_pickle.py
@@ -371,7 +371,7 @@ class GLPickler(_cloudpickle.CloudPickler):
 
         if self.s3_path:
             _file_util.s3_recursive_delete(self.s3_path, \
-                    aws_credentials = _get_aws_credentials(), silent = True)
+                    aws_credentials = _get_aws_credentials())
             _file_util.upload_to_s3(self.gl_temp_storage_path, self.s3_path,
                                     aws_credentials = _get_aws_credentials(),
                                     is_dir = True, silent = True)


### PR DESCRIPTION
The definition in https://github.com/dato-code/SFrame/blob/master/oss_src/unity/python/sframe/util/file_util.py does not have a kwarg named `silent`.