### PR TITLE
Cleans up cython directory on configure.

### DIFF
--- a/configure
+++ b/configure
@@ -304,7 +304,11 @@ fi
 set -e
 set -o pipefail
 
-
+# Delete the cython make files. If cython files get removed,
+# CMake has a tendency to leave the build files around.
+# So we just delete them and reconfigure should take care of it.
+rm -rf ${RELEASE_DIR}/oss_src/unity/python/sframe/cython
+rm -rf ${DEBUG_DIR}/oss_src/unity/python/sframe/cython
 
 echo -e "\n\n\n======================= Release ========================" \
 


### PR DESCRIPTION
This is necessary because CMake for whatever
reason leaves the build scripts around even after cython files get
deleted. So we just delete the cython build directory during
configure and force those build scripts to be regenerated.