### PR TITLE
Fixes an append issue

### DIFF
--- a/oss_src/unity/python/sframe/data_structures/sframe.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe.py
@@ -3755,7 +3755,7 @@ class SFrame(object):
 
         if (left_empty or right_empty):
             non_empty_sframe = self if right_empty else other
-            return non_empty_sframe
+            return non_empty_sframe.__copy__()
 
         my_column_names = self.column_names()
         my_column_types = self.column_types()

--- a/oss_src/unity/python/sframe/test/test_sframe.py
+++ b/oss_src/unity/python/sframe/test/test_sframe.py
@@ -1454,6 +1454,13 @@ class SFrameTest(unittest.TestCase):
         self.assertEqual(sorted(list(res['a'])), sorted([1,2,3,4,None]))
         self.assertEqual(sorted(list(res['b'])), sorted([1,2,3,4,None]))
 
+    def test_append_empty(self):
+        sf_with_data = SFrame(data=self.dataframe)
+        empty_sf = SFrame()
+        self.assertFalse(sf_with_data.append(empty_sf) is sf_with_data)
+        self.assertFalse(empty_sf.append(sf_with_data) is sf_with_data)
+        self.assertFalse(empty_sf.append(empty_sf) is empty_sf)
+
     def test_append_all_match(self):
         sf1 = SFrame(data=self.dataframe)
         sf2 = SFrame(data=self.dataframe2)


### PR DESCRIPTION
Fixes the issue that
sf.append(sf2) may return exactly sf2 if sf is empty (or vice versa)
which leads to interesting issues where after:

   a = sf.append(b)

Changes to a may affect b which is unexpected.