### PR TITLE
Ssl certificate issues

### DIFF
--- a/oss_src/fileio/CMakeLists.txt
+++ b/oss_src/fileio/CMakeLists.txt
@@ -38,6 +38,7 @@ make_library(fileio
     fileio_constants.cpp
     s3_fstream.cpp
     block_cache.cpp
+    set_curl_ssl_options.cpp
     dmlcio/s3_filesys.cc
   REQUIRES
     curl openssl libxml2 logger pthread z cancel_serverside_ops globals process util soft_hdfs ${PLATFORM_DEPENDENCIES} network random

--- a/oss_src/fileio/curl_downloader.cpp
+++ b/oss_src/fileio/curl_downloader.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <cppipc/server/cancel_ops.hpp>
+#include <fileio/set_curl_ssl_options.hpp>
 extern "C" {
 #include <curl/curl.h>
 }
@@ -48,6 +49,7 @@ int download_url(std::string url, std::string output_file) {
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &download_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)(f));
+    graphlab::fileio::set_ssl_certificate_options(curl);
     /* Perform the request, res will get the return code */ 
     res = curl_easy_perform(curl);
     /* Check for errors */ 

--- a/oss_src/fileio/fileio_constants.cpp
+++ b/oss_src/fileio/fileio_constants.cpp
@@ -151,10 +151,10 @@ EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "/etc/pki/tls/certs/ca-bun
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_DIR = "";
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "";
 #endif
-EXPORT int64_t FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS = 0;
+EXPORT int64_t FILEIO_INSECURE_SSL_CERTIFICATE_CHECKS = 0;
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_FILE, true);
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_DIR, true);
-REGISTER_GLOBAL(int64_t, FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS, true);
+REGISTER_GLOBAL(int64_t, FILEIO_INSECURE_SSL_CERTIFICATE_CHECKS, true);
 
 const std::string& get_alternative_ssl_cert_dir() {
   return FILEIO_ALTERNATIVE_SSL_CERT_DIR;
@@ -164,8 +164,8 @@ const std::string& get_alternative_ssl_cert_file() {
   return FILEIO_ALTERNATIVE_SSL_CERT_FILE;
 }
 
-const bool disable_ssl_cert_checks() {
-  return FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS != 0;
+const bool insecure_ssl_cert_checks() {
+  return FILEIO_INSECURE_SSL_CERTIFICATE_CHECKS != 0;
 }
 
 }

--- a/oss_src/fileio/fileio_constants.cpp
+++ b/oss_src/fileio/fileio_constants.cpp
@@ -151,8 +151,10 @@ EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "/etc/pki/tls/certs/ca-bun
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_DIR = "";
 EXPORT std::string FILEIO_ALTERNATIVE_SSL_CERT_FILE = "";
 #endif
+EXPORT int64_t FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS = 0;
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_FILE, true);
 REGISTER_GLOBAL(std::string, FILEIO_ALTERNATIVE_SSL_CERT_DIR, true);
+REGISTER_GLOBAL(int64_t, FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS, true);
 
 const std::string& get_alternative_ssl_cert_dir() {
   return FILEIO_ALTERNATIVE_SSL_CERT_DIR;
@@ -160,6 +162,10 @@ const std::string& get_alternative_ssl_cert_dir() {
 
 const std::string& get_alternative_ssl_cert_file() {
   return FILEIO_ALTERNATIVE_SSL_CERT_FILE;
+}
+
+const bool disable_ssl_cert_checks() {
+  return FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS != 0;
 }
 
 }

--- a/oss_src/fileio/fileio_constants.hpp
+++ b/oss_src/fileio/fileio_constants.hpp
@@ -72,7 +72,7 @@ extern size_t FILEIO_WRITER_BUFFER_SIZE;
  */
 const std::string& get_alternative_ssl_cert_dir();
 const std::string& get_alternative_ssl_cert_file();
-const bool disable_ssl_cert_checks();
+const bool insecure_ssl_cert_checks();
 
 }
 }

--- a/oss_src/fileio/fileio_constants.hpp
+++ b/oss_src/fileio/fileio_constants.hpp
@@ -72,6 +72,7 @@ extern size_t FILEIO_WRITER_BUFFER_SIZE;
  */
 const std::string& get_alternative_ssl_cert_dir();
 const std::string& get_alternative_ssl_cert_file();
+const bool disable_ssl_cert_checks();
 
 }
 }

--- a/oss_src/fileio/s3_api.cpp
+++ b/oss_src/fileio/s3_api.cpp
@@ -456,7 +456,7 @@ list_objects_response list_objects_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
+  if (graphlab::fileio::insecure_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -609,7 +609,7 @@ std::string delete_object_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
+  if (graphlab::fileio::insecure_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -641,7 +641,7 @@ std::string delete_prefix_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
-  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
+  if (graphlab::fileio::insecure_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));

--- a/oss_src/fileio/s3_api.cpp
+++ b/oss_src/fileio/s3_api.cpp
@@ -456,6 +456,7 @@ list_objects_response list_objects_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
+  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -608,6 +609,7 @@ std::string delete_object_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
+  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));
@@ -639,6 +641,7 @@ std::string delete_prefix_impl(s3url parsed_url,
   config.port = NULL;
   config.proxy = proxy.c_str();
   config.host = endpoint.c_str();
+  if (graphlab::fileio::disable_ssl_cert_checks()) config.sslCertFile = "none";
 
   // create connection object.
   std::shared_ptr<WsConnection> conn(new WsConnection(config));

--- a/oss_src/fileio/set_curl_ssl_options.cpp
+++ b/oss_src/fileio/set_curl_ssl_options.cpp
@@ -1,0 +1,27 @@
+#include <fileio/fileio_constants.hpp>
+#include <logger/assertions.hpp>
+extern "C" {
+#include <curl/curl.h>
+}
+
+namespace graphlab {
+namespace fileio {
+
+void set_ssl_certificate_options(void* ecurl) {
+  using graphlab::fileio::get_alternative_ssl_cert_dir;
+  using graphlab::fileio::get_alternative_ssl_cert_file;
+  using graphlab::fileio::disable_ssl_cert_checks;
+  if (!get_alternative_ssl_cert_dir().empty()) {
+    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAPATH, get_alternative_ssl_cert_dir().c_str()), CURLE_OK);
+  }
+  if (!get_alternative_ssl_cert_file().empty()) {
+    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAINFO, get_alternative_ssl_cert_file().c_str()), CURLE_OK);
+  }
+  if (disable_ssl_cert_checks()) {
+    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYPEER, 0l), CURLE_OK);
+    ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYHOST, 0l), CURLE_OK);
+  }
+}
+
+} // fileio
+} // graphlab

--- a/oss_src/fileio/set_curl_ssl_options.cpp
+++ b/oss_src/fileio/set_curl_ssl_options.cpp
@@ -10,14 +10,14 @@ namespace fileio {
 void set_ssl_certificate_options(void* ecurl) {
   using graphlab::fileio::get_alternative_ssl_cert_dir;
   using graphlab::fileio::get_alternative_ssl_cert_file;
-  using graphlab::fileio::disable_ssl_cert_checks;
+  using graphlab::fileio::insecure_ssl_cert_checks;
   if (!get_alternative_ssl_cert_dir().empty()) {
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAPATH, get_alternative_ssl_cert_dir().c_str()), CURLE_OK);
   }
   if (!get_alternative_ssl_cert_file().empty()) {
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_CAINFO, get_alternative_ssl_cert_file().c_str()), CURLE_OK);
   }
-  if (disable_ssl_cert_checks()) {
+  if (insecure_ssl_cert_checks()) {
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYPEER, 0l), CURLE_OK);
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYHOST, 0l), CURLE_OK);
   }

--- a/oss_src/fileio/set_curl_ssl_options.hpp
+++ b/oss_src/fileio/set_curl_ssl_options.hpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#ifndef GRAPHLAB_FILEIO_SET_CURL_SSL_OPTIONS_HPP
+#define GRAPHLAB_FILEIO_SET_CURL_SSL_OPTIONS_HPP
+namespace graphlab {
+namespace fileio {
+
+void set_ssl_certificate_options(void* ecurl);
+}
+}
+#endif

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -380,13 +380,10 @@ def get_runtime_config():
 
 def set_runtime_config(name, value):
     """
-    Sets a runtime configuration value. These configuration values are also
+    Configures sytem behavior at runtime. These configuration values are also
     read from environment variables at program startup if available. See
     :py:func:`graphlab.get_runtime_config()` to get the current values for
     each variable.
-
-    The default configuration is conservatively defined for machines with about
-    4-8GB of RAM.
 
     Note that defaults may change across versions and the names
     of performance tuning constants may also change as improved algorithms
@@ -416,6 +413,19 @@ def set_runtime_config(name, value):
      `GRAPHLAB_CACHE_FILE_LOCATIONS`). On large systems, increasing this as well
      as `GRAPHLAB_FILEIO_MAXIMUM_CACHE_CAPACITY` can improve performance
      significantly for large SFrames. Defaults to 134217728 bytes (128MB).
+
+    **SSL Configuration**
+    - *GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE*
+     The location of an SSL certificate file used to validate HTTPS / S3
+     connections. Defaults to the the Python certifi package certificates.
+
+    - *GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_DIR*
+     The location of an SSL certificate directory used to validate HTTPS / S3
+     connections. Defaults to the operating system certificates.
+
+    - *GRAPHLAB_FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS*
+     If set to a non-zero value, disables all SSL certificate validation.
+     Defaults to False.
 
     **ODBC Configuration**
 

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -380,7 +380,7 @@ def get_runtime_config():
 
 def set_runtime_config(name, value):
     """
-    Configures sytem behavior at runtime. These configuration values are also
+    Configures system behavior at runtime. These configuration values are also
     read from environment variables at program startup if available. See
     :py:func:`graphlab.get_runtime_config()` to get the current values for
     each variable.
@@ -423,7 +423,7 @@ def set_runtime_config(name, value):
      The location of an SSL certificate directory used to validate HTTPS / S3
      connections. Defaults to the operating system certificates.
 
-    - *GRAPHLAB_FILEIO_DISABLE_SSL_CERTIFICATE_CHECKS*
+    - *GRAPHLAB_FILEIO_INSECURE_SSL_CERTIFICATE_CHECKS*
      If set to a non-zero value, disables all SSL certificate validation.
      Defaults to False.
 


### PR DESCRIPTION
 - Some code cleanup (isolates curl option setting code into a single file)
 - added option documentation to get_runtime_config()
 - Added an option to disable all certificate checks. (This is the ultimate fallback option. It also works for accessing files from https)
