### PR TITLE
More certificate issues

### DIFF
--- a/oss_src/fileio/dmlcio/s3_filesys.cc
+++ b/oss_src/fileio/dmlcio/s3_filesys.cc
@@ -379,7 +379,6 @@ void CURLReadStreamBase::Init(size_t begin_bytes) {
   if (FindHttpError(header_)) {
     while (this->FillBuffer(buffer_.length() + 256) != 0);
     std::string message = std::string("Request Error") + header_ + buffer_;
-    logstream(LOG_PROGRESS) << message << std::endl;
     log_and_throw_io_failure(message);
   }
   // setup the variables
@@ -440,7 +439,6 @@ int CURLReadStreamBase::FillBuffer(size_t nwant) {
     m = curl_multi_info_read(mcurl_, &msgq);
     if(m && (m->msg == CURLMSG_DONE)) {
       if (m->data.result != CURLE_OK) {
-        logstream(LOG_PROGRESS) << curl_easy_strerror(m->data.result) << std::endl;
         log_and_throw_io_failure(curl_easy_strerror(m->data.result));
       }
     }
@@ -698,7 +696,7 @@ void WriteStream::Run(const std::string &method,
     }
     CURLcode ret = curl_easy_perform(ecurl_);
     if (ret != CURLE_OK) {
-      logstream(LOG_PROGRESS) << "request " << "failed with error "
+      logstream(LOG_ERROR) << "request " << "failed with error "
                 << curl_easy_strerror(ret) << " Progress " 
                 << etags_.size() << " uploaded " << " retry=" << num_retry << std::endl;
       num_retry += 1;
@@ -714,7 +712,6 @@ void WriteStream::Run(const std::string &method,
   *out_data = rdata.str();
   if (FindHttpError(*out_header) ||
       out_data->find("<Error>") != std::string::npos) {
-    logstream(LOG_PROGRESS) << (std::string("AWS S3 Error:") + *out_header + *out_data) << std::endl;
     if (!no_exception_) {
       log_and_throw_io_failure(std::string("AWS S3 Error:") + *out_header + *out_data);
     }
@@ -809,7 +806,6 @@ void ListObjects(const URI &path,
   // parse xml
   std::string ret = result.str();
   if (ret.find("<Error>") != std::string::npos) {
-    logstream(LOG_PROGRESS) << ret << std::endl;
     log_and_throw_io_failure(ret);
   }
   {// get files

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -72,10 +72,12 @@ def make_unity_server_env():
     ## set local to be c standard so that unity_server will run ##
     env['LC_ALL']='C'
     # add certificate file
-    if 'GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE' not in env:
+    if 'GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE' not in env and \
+            'GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_DIR' not in env:
         try:
             import certifi
             env['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE'] = certifi.where()
+            env['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_DIR'] = ""
         except:
             pass
     return env

--- a/oss_src/unity/python/sframe/test/test_file_util.py
+++ b/oss_src/unity/python/sframe/test/test_file_util.py
@@ -92,3 +92,9 @@ class FileUtilTests(unittest.TestCase):
         (bucket, path) = fu.parse_s3_path(s3_path)
         self.assertEqual(bucket, 'a')
         self.assertEqual(path, 'b/c')
+
+    def test_cert_directories(self):
+        import sframe as sf
+        import certifi
+        self.assertEqual(sf.get_runtime_config()['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_FILE'], certifi.where())
+        self.assertEqual(sf.get_runtime_config()['GRAPHLAB_FILEIO_ALTERNATIVE_SSL_CERT_DIR'], "")


### PR DESCRIPTION
Seems like letting CERT_DIR be the default value can cause problems on
some earlier versions on Linux. So we just force it to the empty string
which will allow us to *only* use the certificates in certifi