### PR TITLE
There was a regression in the python extension code

### DIFF
--- a/oss_src/unity/extensions/internal_demo.cpp
+++ b/oss_src/unity/extensions/internal_demo.cpp
@@ -15,6 +15,10 @@ int _demo_addone(int param) {
   return param + 1;
 }
 
+variant_type _demo_identity(variant_type input) {
+  // this is used in unit tests
+  return input;
+}
 
 double _demo_add(double param, double param2) {
   return param + param2;
@@ -166,6 +170,7 @@ class demo_vector : public std::vector<std::string>, public toolkit_class_base {
 
 BEGIN_FUNCTION_REGISTRATION
 REGISTER_FUNCTION(_demo_addone, "param");
+REGISTER_FUNCTION(_demo_identity, "param");
 REGISTER_FUNCTION(_demo_add, "param", "param2");
 REGISTER_FUNCTION(_demo_to_string, "param");
 REGISTER_FUNCTION(_replicate, "input");

--- a/oss_src/unity/python/sframe/test/test_extensions.py
+++ b/oss_src/unity/python/sframe/test/test_extensions.py
@@ -9,8 +9,6 @@ import unittest
 from ..data_structures.sarray import SArray
 from ..data_structures.sframe import SFrame
 
-sa = SArray([1,2,3,4,5])
-sf = SFrame({'a':sa})
 
 
 class VariantCheckTest(unittest.TestCase):
@@ -38,6 +36,8 @@ class VariantCheckTest(unittest.TestCase):
         self.identical(expected_result, _demo_identity(reference))
 
     def test_variant_check(self):
+        sa = SArray([1,2,3,4,5])
+        sf = SFrame({'a':sa})
         import array
         self.variant_turnaround(1)
         self.variant_turnaround(1.0)

--- a/oss_src/unity/python/sframe/test/test_extensions.py
+++ b/oss_src/unity/python/sframe/test/test_extensions.py
@@ -1,0 +1,61 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+import unittest
+from ..data_structures.sarray import SArray
+from ..data_structures.sframe import SFrame
+
+sa = SArray([1,2,3,4,5])
+sf = SFrame({'a':sa})
+
+
+class VariantCheckTest(unittest.TestCase):
+
+    def identical(self, reference, b):
+        self.assertEquals(type(reference), type(b))
+        if isinstance(reference, list):
+            self.assertEquals(len(reference), len(b))
+            for i in range(len(reference)):
+                self.identical(reference[i], b[i])
+        if isinstance(reference, dict):
+            self.assertEqual(sorted(reference.iterkeys()), sorted(b.iterkeys()))
+            for i in reference:
+                self.identical(reference[i], b[i])
+        if isinstance(reference, SArray):
+            self.identical(list(reference), list(b))
+        if isinstance(reference, SFrame):
+            self.identical(list(reference), list(b))
+            
+
+    def variant_turnaround(self, reference, expected_result=None):
+        if expected_result is None:
+            expected_result = reference
+        from ..extensions import _demo_identity
+        self.identical(expected_result, _demo_identity(reference))
+
+    def test_variant_check(self):
+        import array
+        self.variant_turnaround(1)
+        self.variant_turnaround(1.0)
+        self.variant_turnaround(array.array('d', [1.0, 2.0, 3.0]))
+         # numeric lists currently converts to array
+        self.variant_turnaround([1, 2, 3], array.array('d',[1,.0,2.0,3.0]))
+        self.variant_turnaround("abc")
+        self.variant_turnaround(["abc", "def"])
+        self.variant_turnaround({'a':1,'b':'c'})
+        self.variant_turnaround({'a':[1,2,'d'],'b':['a','b','c']})
+         # numeric lists currently converts to array
+        self.variant_turnaround({'a':[1,2,3],'b':['a','b','c']},
+                                {'a':array.array('d',[1,2,3]),'b':['a','b','c']})
+        self.variant_turnaround(sa)
+        self.variant_turnaround(sf)
+        self.variant_turnaround([sa,sf])
+        self.variant_turnaround([sa,sa])
+        self.variant_turnaround([sf,sf])
+        self.variant_turnaround({'a':sa, 'b':sf, 'c':['a','b','c','d']})
+        self.variant_turnaround({'a':[sa,sf,{'a':sa,'b':'c'}],
+            'b':sf, 'c':['a','b','c','d']})


### PR DESCRIPTION
Conversion of SArray or SFrames to a C++ variant_type ends up
serializing the entire SFrame / SArray as a list.

```
>>> g=SFrame({'a':[1,2,3]})
>>> extensions._demo_identity({'b':g})
will return
{'b':[{'a':1},{'a':2},{'a':3}]} instead of {'b':SFrame...}
```