### PR TITLE
Update spark unity jar

### DIFF
--- a/oss_src/sframe/CMakeLists.txt
+++ b/oss_src/sframe/CMakeLists.txt
@@ -54,6 +54,6 @@ make_copy_target(_local_sys_util_
                   sframe
                   pylambda
  )
-add_dependencies(spark_unity _local_sys_util_i)
+add_dependencies(spark_unity _local_sys_util_)
 file(DOWNLOAD http://s3-us-west-2.amazonaws.com/glbin-engine/spark_unity_0.4.jar ${CMAKE_CURRENT_BINARY_DIR}/spark_unity.jar
       EXPECTED_MD5 1ff73889a5484a90b0f1675641c16488)

--- a/oss_src/sframe/CMakeLists.txt
+++ b/oss_src/sframe/CMakeLists.txt
@@ -54,7 +54,6 @@ make_copy_target(_local_sys_util_
                   sframe
                   pylambda
  )
-add_dependencies(spark_unity _local_sys_util_)
-file(DOWNLOAD http://s3-us-west-2.amazonaws.com/glbin-engine/spark_unity_0.3.jar ${CMAKE_CURRENT_BINARY_DIR}/spark_unity.jar
-      EXPECTED_MD5 b6261c8614da3da1c89dce64fed09420)
-
+add_dependencies(spark_unity _local_sys_util_i)
+file(DOWNLOAD http://s3-us-west-2.amazonaws.com/glbin-engine/spark_unity_0.4.jar ${CMAKE_CURRENT_BINARY_DIR}/spark_unity.jar
+      EXPECTED_MD5 1ff73889a5484a90b0f1675641c16488)


### PR DESCRIPTION
A new version (spark_unity_0.4.jar) is uploaded to s3 bucket. We needed to update version number and md5 code here as well. 