### PR TITLE
Fix failure to find supporting DLLs on Win32

### DIFF
--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -63,7 +63,6 @@ def make_unity_server_env():
     if sys.platform == 'win32':
         env['PATH'] = os.path.dirname(os.path.abspath(_pylambda_worker.__file__)) +\
                 os.path.pathsep + env['PATH']
-                
     
     #### Remove PYTHONEXECUTABLE ####
     # Anaconda overwrites this environment variable

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -61,8 +61,9 @@ def make_unity_server_env():
 
     # For Windows, add path to DLLs for the pylambda_worker
     if sys.platform == 'win32':
-        env['PATH'] = env['PATH'] + os.path.pathsep +\
-                os.path.dirname(os.path.abspath(_pylambda_worker.__file__))
+        env['PATH'] = os.path.dirname(os.path.abspath(_pylambda_worker.__file__)) +\
+                os.path.pathsep + env['PATH']
+                
     
     #### Remove PYTHONEXECUTABLE ####
     # Anaconda overwrites this environment variable

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -58,6 +58,11 @@ def make_unity_server_env():
 
     # Add the pylambda execution script to the runtime config
     env['__GL_PYLAMBDA_SCRIPT__'] = os.path.abspath(_pylambda_worker.__file__)
+
+    # For Windows, add path to DLLs for the pylambda_worker
+    if sys.platform == 'win32':
+        env['PATH'] = env['PATH'] + os.path.pathsep +\
+                os.path.dirname(os.path.abspath(_pylambda_worker.__file__))
     
     #### Remove PYTHONEXECUTABLE ####
     # Anaconda overwrites this environment variable


### PR DESCRIPTION
Since we are launching the pylambda_worker as a DLL from python.exe, we can no
longer expect the supporting DLLs we package within the egg to be found by it.
This augments the path of unity_server on Windows only to add the graphlab path
within site-packages. This environment is inherited by children.