### PR TITLE
GLPickle expandvars and expanduser paths are now supported.

### DIFF
--- a/oss_src/unity/python/sframe/_gl_pickle.py
+++ b/oss_src/unity/python/sframe/_gl_pickle.py
@@ -252,7 +252,9 @@ class GLPickler(_cloudpickle.CloudPickler):
             self.hadoop_conf_dir = None
         else:
             # Make sure the directory exists.
-            filename = _os.path.abspath(filename)
+            filename = _os.path.abspath(
+                         _os.path.expanduser(
+                           _os.path.expandvars(filename)))
             if not _os.path.exists(filename):
                 _os.makedirs(filename)
             elif _os.path.isdir(filename):
@@ -457,6 +459,9 @@ class GLUnpickler(_pickle.Unpickler):
             _file_util.download_from_hdfs(filename, self.tmp_file)
             filename = self.tmp_file
         else:
+            filename = _os.path.abspath(
+                         _os.path.expanduser(
+                           _os.path.expandvars(filename)))
             if not _os.path.exists(filename):
                 raise IOError('%s is not a valid file name.' % filename)
 


### PR DESCRIPTION
We can now do the following

```
        sf1 = SFrame(range(10))
        relative_path = 'tmp/%s' % self.filename

        # Act
        pickler = gl_pickle.GLPickler(relative_path)
        pickler.dump(sf1)
        pickler.close()
        sf2 = gl_pickle.GLUnpickler(relative_path).load()
```

Previously, the '~' wasn't being expanded out to the home directory and was being saved to the current directory.
