### PR TITLE
Minor memory management tweaks

### DIFF
--- a/oss_src/fileio/fixed_size_cache_manager.cpp
+++ b/oss_src/fileio/fixed_size_cache_manager.cpp
@@ -83,7 +83,7 @@ namespace fileio {
     capacity = std::min(FILEIO_INITIAL_CAPACITY_PER_FILE, maximum_capacity);
     size = 0;
     if (capacity > 0) {
-      data = (char*)malloc(capacity);
+      data = new char[capacity];
       owning_cache_manager->increment_utilization(capacity);
     } else {
       data = NULL;
@@ -92,7 +92,7 @@ namespace fileio {
 
   void cache_block::release_memory() {
     if (data) {
-      free(data);
+      delete[] data;
       owning_cache_manager->decrement_utilization(capacity);
     }
     data = NULL;
@@ -129,9 +129,9 @@ namespace fileio {
 /*************************************************************************/
 
  EXPORT fixed_size_cache_manager& fixed_size_cache_manager::get_instance() {
-    static fixed_size_cache_manager* instance = new fixed_size_cache_manager();
-    return *instance;
-  }
+   static std::unique_ptr<fixed_size_cache_manager> instance(new fixed_size_cache_manager);
+   return *instance;
+ }
 
   fixed_size_cache_manager::fixed_size_cache_manager() { }
 

--- a/oss_src/fileio/fixed_size_cache_manager.hpp
+++ b/oss_src/fileio/fixed_size_cache_manager.hpp
@@ -243,11 +243,12 @@ class fixed_size_cache_manager {
   }
 
  private:
-
   fixed_size_cache_manager();
 
+ public:
   ~fixed_size_cache_manager();
 
+ private:
   fixed_size_cache_manager(const fixed_size_cache_manager& other) = delete;
 
   fixed_size_cache_manager& operator=(const fixed_size_cache_manager& other) = delete;


### PR DESCRIPTION
This PR doesn't change any functionality, but it makes it easier to
track down memory leaks elsewhere in the code base with valgrind or
heapprof:

1. std::unique_ptr is used in static global so valgrind doesn't
complain of lost memory.

2. new is used instead of malloc so an std::bad_alloc is raised when
something fails.