### PR TITLE
Added an abstraction for cumulative aggregates.

### DIFF
--- a/oss_src/unity/extensions/CMakeLists.txt
+++ b/oss_src/unity/extensions/CMakeLists.txt
@@ -9,6 +9,7 @@ endmacro()
 make_extension(internal_demo SOURCES internal_demo.cpp)
 make_extension(additional_sframe_utilities SOURCES additional_sframe_utilities.cpp)
 make_extension(grouped_sframe SOURCES grouped_sframe.cpp)
+make_extension(cumulative_aggregates SOURCES cumulative_aggregates.cpp)
 
 #----------------------------
 set_property(DIRECTORY PROPERTY EXTENSIONS_LIST "${EXTENSIONS_LIST}")

--- a/oss_src/unity/extensions/cumulative_aggregates.cpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.cpp
@@ -78,27 +78,51 @@ void check_vector_equal_size(const gl_sarray& in) {
 
 }
 
-gl_sarray _sarray_cumulative_sum(const gl_sarray& in) {
-
+gl_sarray _sarray_cumulative_built_in_aggregate(const gl_sarray& in, 
+                                                const std::string& name) {
   flex_type_enum input_type = in.dtype();
   std::shared_ptr<group_aggregate_value> aggregator;
-  switch(input_type) {
-    case flex_type_enum::VECTOR: 
-    {
-      check_vector_equal_size(in);
-      aggregator = get_builtin_group_aggregator(std::string("__builtin__vector__sum__")); 
-      break;
+
+  // Cumulative sum, and avg support vector types.
+  if (name == "__builtin__cum_sum__") {
+    switch(input_type) {
+      case flex_type_enum::VECTOR: {
+        check_vector_equal_size(in);
+        aggregator = get_builtin_group_aggregator(std::string("__builtin__vector__sum__")); 
+        break;
+      }
+      default:
+        aggregator = get_builtin_group_aggregator(std::string("__builtin__sum__")); 
+        break;
     }
-    default:
-      aggregator = get_builtin_group_aggregator(std::string("__builtin__sum__")); 
-      break;
+  } else if (name == "__builtin__cum_avg__") {
+    switch(input_type) {
+      case flex_type_enum::VECTOR: {
+        check_vector_equal_size(in);
+        aggregator = get_builtin_group_aggregator(std::string("__builtin__vector__avg__")); 
+        break;
+      }
+      default:
+        aggregator = get_builtin_group_aggregator(std::string("__builtin__avg__")); 
+        break;
+    }
+  } else if (name == "__builtin__cum_max__") {
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__max__")); 
+  } else if (name == "__builtin__cum_min__") {
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__min__")); 
+  } else if (name == "__builtin__cum_var__") {
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__var__")); 
+  } else if (name == "__builtin__cum_std__") {
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__stdv__")); 
+  } else {
+    log_and_throw("Internal error. Unknown cumulative aggregator " + name);
   }
   return in.cumulative_aggregate(aggregator);
 }
 
 
 BEGIN_FUNCTION_REGISTRATION
-REGISTER_FUNCTION(_sarray_cumulative_sum, "in");
+REGISTER_FUNCTION(_sarray_cumulative_built_in_aggregate, "in", "name");
 END_FUNCTION_REGISTRATION
 
 }

--- a/oss_src/unity/extensions/cumulative_aggregates.cpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.cpp
@@ -23,7 +23,7 @@ void check_vector_equal_size(const gl_sarray& in) {
   // Initialize. 
   DASSERT_TRUE(in.dtype() == flex_type_enum::VECTOR); 
   size_t n_threads = thread::cpu_count();
-  DASSERT_GE(n_threads, 1);
+  n_threads = std::max(n_threads, 1);
   size_t m_size = in.size();
           
   // Throw the following error. 

--- a/oss_src/unity/extensions/cumulative_aggregates.cpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.cpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#include <unity/lib/toolkit_function_macros.hpp>
+#include <unity/extensions/cumulative_aggregates.hpp>
+
+namespace graphlab {
+namespace cumulative_aggregates {
+
+template <typename AggregateFunctionType, 
+          typename AccumulatorType> 
+gl_sarray cumulative_aggregate(const gl_sarray& in,
+                     AggregateFunctionType aggregate_fn, 
+                     AccumulatorType init,
+                     flex_type_enum output_type) {
+  
+  // Empty case.  
+  size_t m_size = in.size();
+  if (m_size == 0) {
+    return gl_sarray({});
+  } 
+  
+  gl_sarray_writer writer(output_type, 1);
+  AccumulatorType y = init; 
+  for (const auto& v: in.range_iterator()) {
+    writer.write(aggregate_fn(v, y), 0); // z[t+1], y[t+1] = f(x[t], y[y]) 
+  }
+  return writer.close();
+}
+
+
+gl_sarray _sarray_cumulative_sum(gl_sarray in) {
+
+  // Check types.
+  flex_type_enum dt = in.dtype();
+  if (dt != flex_type_enum::INTEGER && 
+      dt != flex_type_enum::FLOAT &&
+      dt != flex_type_enum::VECTOR) {
+    log_and_throw("SArray must be of type int, float, or array.");
+  }
+ 
+  flexible_type start_val = FLEX_UNDEFINED;
+  switch (dt) {
+
+    case flex_type_enum::INTEGER:
+    case flex_type_enum::FLOAT:
+    {
+      auto aggregate_fn = []
+        (const flexible_type& v, flexible_type& y) -> flexible_type {
+          if (v != FLEX_UNDEFINED) {
+            if (y == FLEX_UNDEFINED) {
+              y = v;
+            } else {
+              y += v;
+            }
+          }
+          return y;
+        };
+      return cumulative_aggregate(in, aggregate_fn, start_val, dt); 
+    }
+    break;
+
+    case flex_type_enum::VECTOR:
+    {
+      auto aggregate_fn = []
+        (const flexible_type& v, flexible_type& y) -> flexible_type {
+          if (v != FLEX_UNDEFINED) {
+            if (y == FLEX_UNDEFINED) {
+              y = v;
+            } else {
+              if (v.size() != y.size()) {
+                log_and_throw(
+   "Cannot perform cumulative_sum on SArray with vectors of different lengths.");
+              }
+              y += v;
+            }
+          }
+          return y;
+        };
+      return cumulative_aggregate(in, aggregate_fn, start_val, dt); 
+    }
+    break;
+
+    // This should never happen. 
+    default:
+      DASSERT_TRUE(false);
+      break;
+  }
+}
+
+
+BEGIN_FUNCTION_REGISTRATION
+REGISTER_FUNCTION(_sarray_cumulative_sum, "in");
+END_FUNCTION_REGISTRATION
+
+}
+}

--- a/oss_src/unity/extensions/cumulative_aggregates.cpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.cpp
@@ -5,91 +5,95 @@
  * This software may be modified and distributed under the terms
  * of the BSD license. See the LICENSE file for details.
  */
+#include <parallel/pthread_tools.hpp>
+#include <parallel/lambda_omp.hpp>
 #include <unity/lib/toolkit_function_macros.hpp>
 #include <unity/extensions/cumulative_aggregates.hpp>
 
 namespace graphlab {
 namespace cumulative_aggregates {
 
-template <typename AggregateFunctionType, 
-          typename AccumulatorType> 
-gl_sarray cumulative_aggregate(const gl_sarray& in,
-                     AggregateFunctionType aggregate_fn, 
-                     AccumulatorType init,
-                     flex_type_enum output_type) {
+
+/**
+ * Throw an error if a vector is of unequal length.
+ * \param[in] gl_sarray of type vector 
+ */
+void check_vector_equal_size(const gl_sarray& in) {
   
-  // Empty case.  
+  // Initialize. 
+  DASSERT_TRUE(in.dtype() == flex_type_enum::VECTOR); 
+  size_t n_threads = thread::cpu_count();
+  DASSERT_GE(n_threads, 1);
   size_t m_size = in.size();
-  if (m_size == 0) {
-    return gl_sarray({});
-  } 
+          
+  // Throw the following error. 
+  auto throw_error = [] (size_t row_number, size_t expected, size_t current) {
+    std::stringstream ss;
+    ss << "Vectors must be of the same size. Row " << row_number 
+       << " contains a vector of size " << current << ". Expected a vector of"
+       << " size " << expected << "." << std::endl;
+    log_and_throw(ss.str());
+  };
   
-  gl_sarray_writer writer(output_type, 1);
-  AccumulatorType y = init; 
-  for (const auto& v: in.range_iterator()) {
-    writer.write(aggregate_fn(v, y), 0); // z[t+1], y[t+1] = f(x[t], y[y]) 
+
+  // Within each block of the SArray, check that the vectors have the same size.
+  std::vector<size_t> expected_sizes (n_threads, size_t(-1));
+  in_parallel([&](size_t thread_idx, size_t n_threads) {
+    size_t start_row = thread_idx * m_size / n_threads; 
+    size_t end_row = (thread_idx + 1) * m_size / n_threads;
+    size_t expected_size = size_t(-1);
+    size_t row_number = start_row;
+    for (const auto& v: in.range_iterator(start_row, end_row)) {
+      if (v != FLEX_UNDEFINED) {
+        if (expected_size == size_t(-1)) {
+          expected_size = v.size();
+          expected_sizes[thread_idx] = expected_size; 
+        } else {
+          DASSERT_TRUE(v.get_type() == flex_type_enum::VECTOR);
+          if (expected_size != v.size()) {
+            throw_error(row_number, expected_size, v.size());
+          }
+        }
+      }
+      row_number++;
+    }
+  });
+
+  // Make sure sizes accross blocks are also the same. 
+  size_t vector_size = size_t(-1);
+  for (size_t thread_idx = 0; thread_idx < n_threads; thread_idx++) {
+    // If this block contains all None values, skip it.
+    if (expected_sizes[thread_idx] != size_t(-1)) {
+
+      if (vector_size == size_t(-1)) {
+          vector_size = expected_sizes[thread_idx]; 
+      } else {
+         if (expected_sizes[thread_idx] != vector_size) {
+           throw_error(thread_idx * m_size / n_threads, 
+                              vector_size, expected_sizes[thread_idx]);
+         } 
+      }
+    }
   }
-  return writer.close();
+
 }
 
+gl_sarray _sarray_cumulative_sum(const gl_sarray& in) {
 
-gl_sarray _sarray_cumulative_sum(gl_sarray in) {
-
-  // Check types.
-  flex_type_enum dt = in.dtype();
-  if (dt != flex_type_enum::INTEGER && 
-      dt != flex_type_enum::FLOAT &&
-      dt != flex_type_enum::VECTOR) {
-    log_and_throw("SArray must be of type int, float, or array.");
-  }
- 
-  flexible_type start_val = FLEX_UNDEFINED;
-  switch (dt) {
-
-    case flex_type_enum::INTEGER:
-    case flex_type_enum::FLOAT:
+  flex_type_enum input_type = in.dtype();
+  std::shared_ptr<group_aggregate_value> aggregator;
+  switch(input_type) {
+    case flex_type_enum::VECTOR: 
     {
-      auto aggregate_fn = []
-        (const flexible_type& v, flexible_type& y) -> flexible_type {
-          if (v != FLEX_UNDEFINED) {
-            if (y == FLEX_UNDEFINED) {
-              y = v;
-            } else {
-              y += v;
-            }
-          }
-          return y;
-        };
-      return cumulative_aggregate(in, aggregate_fn, start_val, dt); 
+      check_vector_equal_size(in);
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__vector__sum__")); 
+      break;
     }
-    break;
-
-    case flex_type_enum::VECTOR:
-    {
-      auto aggregate_fn = []
-        (const flexible_type& v, flexible_type& y) -> flexible_type {
-          if (v != FLEX_UNDEFINED) {
-            if (y == FLEX_UNDEFINED) {
-              y = v;
-            } else {
-              if (v.size() != y.size()) {
-                log_and_throw(
-   "Cannot perform cumulative_sum on SArray with vectors of different lengths.");
-              }
-              y += v;
-            }
-          }
-          return y;
-        };
-      return cumulative_aggregate(in, aggregate_fn, start_val, dt); 
-    }
-    break;
-
-    // This should never happen. 
     default:
-      DASSERT_TRUE(false);
+      aggregator = get_builtin_group_aggregator(std::string("__builtin__sum__")); 
       break;
   }
+  return in.cumulative_aggregate(aggregator);
 }
 
 

--- a/oss_src/unity/extensions/cumulative_aggregates.cpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.cpp
@@ -23,7 +23,7 @@ void check_vector_equal_size(const gl_sarray& in) {
   // Initialize. 
   DASSERT_TRUE(in.dtype() == flex_type_enum::VECTOR); 
   size_t n_threads = thread::cpu_count();
-  n_threads = std::max(n_threads, 1);
+  n_threads = std::max(n_threads, size_t(1));
   size_t m_size = in.size();
           
   // Throw the following error. 

--- a/oss_src/unity/extensions/cumulative_aggregates.hpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef EXTENSIONS_CUMULATIVE_AGGREGATES_HPP
+#define EXTENSIONS_CUMULATIVE_AGGREGATES_HPP
+#include <unity/lib/gl_sarray.hpp>
+#include <unity/lib/toolkit_function_specification.hpp>
+
+namespace graphlab {
+namespace cumulative_aggregates {
+
+std::vector<toolkit_function_specification> 
+                       get_toolkit_function_registration();
+
+/**
+ *
+ *  An abstraction to perform cumulative aggregates.
+ *    y <- x.cumulative_aggregate(f, w_0)
+ *
+ *  The abstraction is as follows:
+ *    y[i+1], w[i+1] = func(x[i], w[i])
+ *
+ *  where w[i] is some arbitary state.
+ *
+ *  You can implement cumulative_sum as follows.
+ *
+ *   auto cumsum_agg = []
+ *     (const flexible_type& v, flexible_type& y) -> flexible_type {
+ *      y += v;
+ *      return y
+ *   };
+ *   out_sa = in_sa.cumulative_aggregate(agg_fn, 0);
+ *
+ * \param[in] Function to perform the aggregate to keep track of state.
+ * \return SArray 
+ */
+ template <typename AggregateFunctionType, 
+           typename AccumulatorType>
+ gl_sarray cumulative_aggregate(
+                const gl_sarray& in,
+                AggregateFunctionType aggregate_fn, 
+                AccumulatorType init,
+                flex_type_enum output_type);
+
+/**
+ *
+ *  Functional form of the pre-built cumulative aggregates.
+ *
+ *  \param[in] Input SArray
+ *  \return SArray of cumulative aggregate of the input SArray.
+ */
+gl_sarray _sarray_cumulative_sum(gl_sarray in);
+
+}
+}
+#endif

--- a/oss_src/unity/extensions/cumulative_aggregates.hpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.hpp
@@ -24,7 +24,8 @@ std::vector<toolkit_function_specification>
  *  \param[in] Input SArray
  *  \return SArray of cumulative aggregate of the input SArray.
  */
-gl_sarray _sarray_cumulative_sum(const gl_sarray& in);
+gl_sarray _sarray_cumulative_built_in_aggregate(const gl_sarray& in, 
+                                                const std::string& name);
 
 }
 }

--- a/oss_src/unity/extensions/cumulative_aggregates.hpp
+++ b/oss_src/unity/extensions/cumulative_aggregates.hpp
@@ -18,42 +18,13 @@ std::vector<toolkit_function_specification>
 
 /**
  *
- *  An abstraction to perform cumulative aggregates.
- *    y <- x.cumulative_aggregate(f, w_0)
- *
- *  The abstraction is as follows:
- *    y[i+1], w[i+1] = func(x[i], w[i])
- *
- *  where w[i] is some arbitary state.
- *
- *  You can implement cumulative_sum as follows.
- *
- *   auto cumsum_agg = []
- *     (const flexible_type& v, flexible_type& y) -> flexible_type {
- *      y += v;
- *      return y
- *   };
- *   out_sa = in_sa.cumulative_aggregate(agg_fn, 0);
- *
- * \param[in] Function to perform the aggregate to keep track of state.
- * \return SArray 
- */
- template <typename AggregateFunctionType, 
-           typename AccumulatorType>
- gl_sarray cumulative_aggregate(
-                const gl_sarray& in,
-                AggregateFunctionType aggregate_fn, 
-                AccumulatorType init,
-                flex_type_enum output_type);
-
-/**
- *
- *  Functional form of the pre-built cumulative aggregates.
+ *  Functional form of the pre-built cumulative aggregates. These functions 
+ *  are exposed to the user as extensions.
  *
  *  \param[in] Input SArray
  *  \return SArray of cumulative aggregate of the input SArray.
  */
-gl_sarray _sarray_cumulative_sum(gl_sarray in);
+gl_sarray _sarray_cumulative_sum(const gl_sarray& in);
 
 }
 }

--- a/oss_src/unity/lib/CMakeLists.txt
+++ b/oss_src/unity/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ make_library(unity_core
     unity_odbc_connection.cpp
     image_util.cpp
     ../extensions/additional_sframe_utilities.cpp
+    ../extensions/cumulative_aggregates.cpp
   REQUIRES
     flexible_type
     pylambda table_printer

--- a/oss_src/unity/lib/gl_sarray.cpp
+++ b/oss_src/unity/lib/gl_sarray.cpp
@@ -662,7 +662,7 @@ gl_sarray gl_sarray::cumulative_aggregate(
     if (thread_idx >= 1) {
       DASSERT_TRUE(thread_idx - 1 < aggregators.size());
       y = aggregators[thread_idx - 1]->emit();
-      re_aggregator->add_element_simple(y);
+      re_aggregator->combine(*aggregators[thread_idx - 1]);
     }
 
     // Write prefix-sum
@@ -678,7 +678,28 @@ gl_sarray gl_sarray::cumulative_aggregate(
 }
 
 gl_sarray gl_sarray::cumulative_sum() const {
-  return cumulative_aggregates::_sarray_cumulative_sum(*this);
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_sum__");
+}
+gl_sarray gl_sarray::cumulative_min() const {
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_min__");
+}
+gl_sarray gl_sarray::cumulative_max() const {
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_max__");
+}
+gl_sarray gl_sarray::cumulative_avg() const {
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_avg__");
+}
+gl_sarray gl_sarray::cumulative_std() const {
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_std__");
+}
+gl_sarray gl_sarray::cumulative_var() const {
+  return cumulative_aggregates::_sarray_cumulative_built_in_aggregate(
+      *this, "__builtin__cum_var__");
 }
 
 std::ostream& operator<<(std::ostream& out, const gl_sarray& other) {

--- a/oss_src/unity/lib/gl_sarray.cpp
+++ b/oss_src/unity/lib/gl_sarray.cpp
@@ -597,7 +597,87 @@ gl_sarray gl_sarray::subslice(flexible_type start,
   return sarray_subslice(*this, start, stop, step);
 }
 
-gl_sarray gl_sarray::cumulative_sum() {
+
+gl_sarray gl_sarray::cumulative_aggregate(
+     std::shared_ptr<group_aggregate_value> aggregator) const { 
+  
+  flex_type_enum input_type = this->dtype();
+  flex_type_enum output_type = aggregator->set_input_types({input_type});
+  if (! aggregator->support_type(input_type)) {
+    std::stringstream ss;
+    ss << "Cannot perform this operation on an SArray of type "
+       << flex_type_enum_to_name(input_type) << "." << std::endl;
+    log_and_throw(ss.str());
+  } 
+
+  // Empty case.  
+  size_t m_size = this->size();
+  if (m_size == 0) {
+    return gl_sarray({}, output_type);
+  }
+
+  // Make a copy of an newly initialize aggregate for each thread.
+  size_t n_threads = thread::cpu_count();
+  std::vector<std::shared_ptr<group_aggregate_value>> aggregators;
+  for (size_t i = 0; i < n_threads; i++) {
+      aggregators.push_back(
+          std::shared_ptr<group_aggregate_value>(aggregator->new_instance()));
+  } 
+
+  gl_sarray_writer writer(output_type, n_threads);
+
+  // If n_threads = 1, then skip Phase 1 and Phase 2.
+  if (n_threads > 1) {
+    
+    // Phase 1: Compute prefix-sums for each block.
+    in_parallel([&](size_t thread_idx, size_t n_threads) {
+      size_t start_row = thread_idx * m_size / n_threads; 
+      size_t end_row = (thread_idx + 1) * m_size / n_threads;
+      for (const auto& v: this->range_iterator(start_row, end_row)) {
+        DASSERT_TRUE(thread_idx < aggregators.size());
+        if (v != FLEX_UNDEFINED) {
+          aggregators[thread_idx]->add_element_simple(v);
+        }
+      }
+    });
+
+    // Phase 2: Combine prefix-sum(s) at the end of each block.
+    for (size_t i = n_threads - 1; i > 0; i--) {
+      for (size_t j = 0; j < i; j++) {
+        DASSERT_TRUE(i < aggregators.size());
+        DASSERT_TRUE(j < aggregators.size());
+        aggregators[i]->combine(*aggregators[j]);
+      }
+    }
+  }
+  
+  // Phase 3: Reaggregate with an re-intialized prefix-sum from previous blocks. 
+  in_parallel([&](size_t thread_idx, size_t n_threads) {
+    flexible_type y = FLEX_UNDEFINED;
+    size_t start_row = thread_idx * m_size / n_threads; 
+    size_t end_row = (thread_idx + 1) * m_size / n_threads;
+    std::shared_ptr<group_aggregate_value> re_aggregator (aggregator->new_instance());
+  
+    // Initialize with the merged value. 
+    if (thread_idx >= 1) {
+      DASSERT_TRUE(thread_idx - 1 < aggregators.size());
+      y = aggregators[thread_idx - 1]->emit();
+      re_aggregator->add_element_simple(y);
+    }
+
+    // Write prefix-sum
+    for (const auto& v: this->range_iterator(start_row, end_row)) {
+      if (v != FLEX_UNDEFINED) {
+        re_aggregator->add_element_simple(v);
+        y = re_aggregator->emit();
+      }
+      writer.write(y, thread_idx);
+    }
+  });
+  return writer.close();
+}
+
+gl_sarray gl_sarray::cumulative_sum() const {
   return cumulative_aggregates::_sarray_cumulative_sum(*this);
 }
 

--- a/oss_src/unity/lib/gl_sarray.cpp
+++ b/oss_src/unity/lib/gl_sarray.cpp
@@ -16,6 +16,7 @@
 #include <unity/lib/image_util.hpp>
 #include <sframe_query_engine/planning/planner.hpp>
 #include <unity/extensions/additional_sframe_utilities.hpp>
+#include <unity/extensions/cumulative_aggregates.hpp>
 
 namespace graphlab {
 
@@ -594,6 +595,10 @@ gl_sarray gl_sarray::subslice(flexible_type start,
     log_and_throw("SArray must contain strings, arrays or lists");
   }
   return sarray_subslice(*this, start, stop, step);
+}
+
+gl_sarray gl_sarray::cumulative_sum() {
+  return cumulative_aggregates::_sarray_cumulative_sum(*this);
 }
 
 std::ostream& operator<<(std::ostream& out, const gl_sarray& other) {

--- a/oss_src/unity/lib/gl_sarray.hpp
+++ b/oss_src/unity/lib/gl_sarray.hpp
@@ -1739,13 +1739,18 @@ class gl_sarray {
 
   /**
    *
-   *  This returns an SArray where each element is a cumulative sum of 
-   *  all its previous elements. Only works in an SArray of numeric type
-   *  or numeric-array types. 
+   *  This returns an SArray where each element is a cumulative aggregate of
+   *  all its previous elements. Only works in an SArray of numeric type or
+   *  numeric-array types. 
    *
-   *  \return an SArray with cumulative sums. 
+   *  \return an SArray 
    */
   gl_sarray cumulative_sum() const;
+  gl_sarray cumulative_min() const;
+  gl_sarray cumulative_max() const;
+  gl_sarray cumulative_var() const;
+  gl_sarray cumulative_std() const;
+  gl_sarray cumulative_avg() const;
 
   /**
    * \internal

--- a/oss_src/unity/lib/gl_sarray.hpp
+++ b/oss_src/unity/lib/gl_sarray.hpp
@@ -1719,6 +1719,16 @@ class gl_sarray {
   gl_sarray subslice(flexible_type start = FLEX_UNDEFINED, 
                      flexible_type stop = FLEX_UNDEFINED, 
                      flexible_type step = FLEX_UNDEFINED);
+  
+  /**
+   *
+   *  This returns an SArray where each element is a cumulative sum of 
+   *  all its previous elements. Only works in an SArray of numeric type
+   *  or numeric-array types. 
+   *
+   *  \return an SArray with cumulative sums. 
+   */
+  gl_sarray cumulative_sum();
 
   /**
    * \internal

--- a/oss_src/unity/lib/gl_sarray.hpp
+++ b/oss_src/unity/lib/gl_sarray.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <iostream>
 #include <sframe/sframe_rows.hpp>
+#include <sframe/group_aggregate_value.hpp>
 #include <flexible_type/flexible_type.hpp>
 
 namespace graphlab {
@@ -1720,6 +1721,22 @@ class gl_sarray {
                      flexible_type stop = FLEX_UNDEFINED, 
                      flexible_type step = FLEX_UNDEFINED);
   
+/**
+ *
+ *  An abstraction to perform cumulative aggregates.
+ *    y <- x.cumulative_aggregate(f, w_0)
+ *
+ *  The abstraction is as follows:
+ *    y[i+1], w[i+1] = func(x[i], w[i])
+ *
+ *  where w[i] is some arbitary state.
+ *
+ * \param[in] Function to perform the aggregate to keep track of state.
+ * \return SArray 
+ */
+ gl_sarray cumulative_aggregate(
+     std::shared_ptr<group_aggregate_value> aggregator) const; 
+
   /**
    *
    *  This returns an SArray where each element is a cumulative sum of 
@@ -1728,7 +1745,7 @@ class gl_sarray {
    *
    *  \return an SArray with cumulative sums. 
    */
-  gl_sarray cumulative_sum();
+  gl_sarray cumulative_sum() const;
 
   /**
    * \internal

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -3056,6 +3056,8 @@ class SArray(object):
         -----
          - Missing values are ignored while performing the cumulative
            aggregate operation.
+         - For SArray's of type array.array, all entries are expected to
+           be of the same size.
 
         Examples
         --------
@@ -3087,6 +3089,8 @@ class SArray(object):
         -----
          - Missing values are ignored while performing the cumulative
            aggregate operation.
+         - For SArray's of type array.array, all entries are expected to
+           be of the same size.
 
         Examples
         --------
@@ -3111,7 +3115,7 @@ class SArray(object):
 
         Returns
         -------
-        out : SArray[int, float, array.array]
+        out : SArray[int, float]
 
         Notes
         -----
@@ -3141,7 +3145,7 @@ class SArray(object):
 
         Returns
         -------
-        out : SArray[int, float, array.array]
+        out : SArray[int, float]
 
         Notes
         -----
@@ -3171,7 +3175,7 @@ class SArray(object):
 
         Returns
         -------
-        out : SArray[int, float, array.array]
+        out : SArray[int, float]
 
         Notes
         -----
@@ -3201,7 +3205,7 @@ class SArray(object):
 
         Returns
         -------
-        out : SArray[int, float, array.array]
+        out : SArray[int, float]
 
         Notes
         -----

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -3039,3 +3039,23 @@ class SArray(object):
         sf = _SFrame()
         sf['a'] = self
         return sf.sort('a', ascending)['a']
+
+    def cumulative_sum(self):
+        """
+        Compute the cumulative sum of the elements.
+
+        Returns
+        -------
+        out : SArray
+
+        Examples
+        --------
+        >>> sa = SArray([3,2,1])
+        >>> sa.cumulative_sum()
+        dtype: int
+        Rows: 3
+        [1, 2, 3]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_sum')
+        return extensions._sarray_cumulative_sum(self)

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -3042,20 +3042,182 @@ class SArray(object):
 
     def cumulative_sum(self):
         """
-        Compute the cumulative sum of the elements.
+        Return the cumulative sum of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        sum of all the elements preceding and including it. The SArray is
+        expected to be of numeric type (int, float), or a numeric vector type.
 
         Returns
         -------
-        out : SArray
+        out : sarray[int, float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
 
         Examples
         --------
-        >>> sa = SArray([3,2,1])
+        >>> sa = SArray([1, 2, 3, 4, 5])
         >>> sa.cumulative_sum()
         dtype: int
-        Rows: 3
-        [1, 2, 3]
+        rows: 3
+        [1, 3, 6, 10, 15]
         """
         from .. import extensions
         _mt._get_metric_tracker().track('sarray.cumulative_sum')
-        return extensions._sarray_cumulative_sum(self)
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_sum__")
+
+    def cumulative_mean(self):
+        """
+        Return the cumulative mean of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        mean value of all the elements preceding and including it. The SArray
+        is expected to be of numeric type (int, float), or a numeric vector
+        type.
+
+        Returns
+        -------
+        out : Sarray[float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
+
+        Examples
+        --------
+        >>> sa = SArray([1, 2, 3, 4, 5])
+        >>> sa.cumulative_mean()
+        dtype: float
+        rows: 3
+        [1, 1.5, 2, 2.5, 3]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_mean')
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_avg__")
+
+    def cumulative_min(self):
+        """
+        Return the cumulative minimum value of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        minimum value of all the elements preceding and including it. The
+        SArray is expected to be of numeric type (int, float).
+
+        Returns
+        -------
+        out : SArray[int, float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
+
+        Examples
+        --------
+        >>> sa = SArray([1, 2, 3, 4, 0])
+        >>> sa.cumulative_min()
+        dtype: int
+        rows: 3
+        [1, 1, 1, 1, 0]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_min')
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_min__")
+
+    def cumulative_max(self):
+        """
+        Return the cumulative maximum value of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        maximum value of all the elements preceding and including it. The
+        SArray is expected to be of numeric type (int, float).
+
+        Returns
+        -------
+        out : SArray[int, float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
+
+        Examples
+        --------
+        >>> sa = SArray([1, 0, 3, 4, 2])
+        >>> sa.cumulative_max()
+        dtype: int
+        rows: 3
+        [1, 1, 3, 4, 4]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_max')
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_max__")
+
+    def cumulative_std(self):
+        """
+        Return the cumulative standard deviation of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        standard deviation of all the elements preceding and including it. The
+        SArray is expected to be of numeric type, or a numeric vector type.
+
+        Returns
+        -------
+        out : SArray[int, float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
+
+        Examples
+        --------
+        >>> sa = SArray([1, 2, 3, 4, 0])
+        >>> sa.cumulative_std()
+        dtype: float
+        rows: 3
+        [0.0, 0.5, 0.816496580927726, 1.118033988749895, 1.4142135623730951]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_std')
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_std__")
+
+    def cumulative_var(self):
+        """
+        Return the cumulative variance of the elements in the SArray.
+
+        Returns an SArray where each element in the output corresponds to the
+        variance of all the elements preceding and including it. The SArray is
+        expected to be of numeric type, or a numeric vector type.
+
+        Returns
+        -------
+        out : SArray[int, float, array.array]
+
+        Notes
+        -----
+         - Missing values are ignored while performing the cumulative
+           aggregate operation.
+
+        Examples
+        --------
+        >>> sa = SArray([1, 2, 3, 4, 0])
+        >>> sa.cumulative_var()
+        dtype: float
+        rows: 3
+        [0.0, 0.25, 0.6666666666666666, 1.25, 2.0]
+        """
+        from .. import extensions
+        _mt._get_metric_tracker().track('sarray.cumulative_var')
+        return extensions._sarray_cumulative_built_in_aggregate(
+                                          self, "__builtin__cum_var__")
+

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -1691,6 +1691,7 @@ class SArrayTest(unittest.TestCase):
     @nottest
     def cumulative_aggregate_comparison(self, out, ans):
         import array
+        self.assertEqual(out.dtype(), ans.dtype())
         self.assertEqual(out.size(), ans.size())
         for i in range(len(out)):
             if out[i] is None:
@@ -1751,3 +1752,193 @@ class SArrayTest(unittest.TestCase):
             SArray([None, [33.0, 3.0], [33.0, 3.0], [37.0, 7.0]])
         )
 
+    def test_cumulative_mean(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_mean();
+            self.cumulative_aggregate_comparison(out, ans)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_mean()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_mean()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_mean()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1,1], [1], [1]]).cumulative_mean()
+
+        single_test(
+          SArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+          SArray([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+        )
+        single_test(
+            SArray([0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1]),
+            SArray([0.1, 0.6, 1.1, 1.6, 2.1, 2.6, 3.1, 3.6])
+        )
+        single_test(
+            SArray([[11.0, 22.0], [33.0, 66.0], [4.0,   2.0],  [4.0,  2.0]]),
+            SArray([[11.0, 22.0], [22.0, 44.0], [16.0, 30.0], [13.0, 23.0]])
+        )
+        single_test(
+            SArray([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            SArray([None, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+        )
+        single_test(
+            SArray([None, 1, None, 3, None, 5]),
+            SArray([None, 1, 1.0, 2.0, 2.0, 3.0])
+        )
+        single_test(
+            SArray([None, [11.0, 22.0], [33.0, 66.0], [4.0,   2.0]]),
+            SArray([None, [11.0, 22.0], [22.0, 44.0], [16.0, 30.0]])
+        )
+        single_test(
+            SArray([None, [11.0, 22.0], None, [33.0, 66.0], [4.0, 2.0]]),
+            SArray([None, [11.0, 22.0], [11.0, 22.0], [22.0, 44.0], [16.0, 30.0]])
+        )
+
+
+    def test_cumulative_min(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_min();
+            self.cumulative_aggregate_comparison(out, ans)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_min()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_min()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_min()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1,1], [1], [1]]).cumulative_min()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1], [1], [1]]).cumulative_min()
+
+        single_test(
+          SArray([0, 1, 2, 3, 4, 5, -1, 7, 8, -2, 10]),
+          SArray([0, 0, 0, 0, 0, 0, -1, -1, -1, -2, -2])
+        )
+        single_test(
+            SArray([7.1, 6.1, 3.1, 3.9, 4.1, 2.1, 2.9, 0.1]),
+            SArray([7.1, 6.1, 3.1, 3.1, 3.1, 2.1, 2.1, 0.1])
+        )
+        single_test(
+            SArray([None, 8, 6, 3, 4, None, 6, 2, 8, 9, 1]),
+            SArray([None, 8, 6, 3, 3, 3,    3, 2, 2, 2, 1])
+        )
+        single_test(
+            SArray([None, 5, None, 3, None, 10]),
+            SArray([None, 5, 5, 3, 3, 3])
+        )
+
+    def test_cumulative_max(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_max();
+            self.cumulative_aggregate_comparison(out, ans)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_max()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_max()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_max()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1,1], [1], [1]]).cumulative_max()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1], [1], [1]]).cumulative_max()
+
+        single_test(
+          SArray([0, 1, 0, 3, 5, 4, 1, 7, 6, 2, 10]),
+          SArray([0, 1, 1, 3, 5, 5, 5, 7, 7, 7, 10])
+        )
+        single_test(
+            SArray([2.1, 6.1, 3.1, 3.9, 2.1, 8.1, 8.9, 10.1]),
+            SArray([2.1, 6.1, 6.1, 6.1, 6.1, 8.1, 8.9, 10.1])
+        )
+        single_test(
+            SArray([None, 1, 6, 3, 4, None, 4, 2, 8, 9, 1]),
+            SArray([None, 1, 6, 6, 6, 6,    6, 6, 8, 9, 9])
+        )
+        single_test(
+            SArray([None, 2, None, 3, None, 10]),
+            SArray([None, 2, 2, 3, 3, 10])
+        )
+
+    def test_cumulative_std(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_std();
+            self.cumulative_aggregate_comparison(out, ans)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_std()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_std()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_std()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1,1], [1], [1]]).cumulative_std()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1], [1], [1]]).cumulative_std()
+
+        single_test(
+          SArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+          SArray([0.0, 0.5, 0.816496580927726, 1.118033988749895,
+              1.4142135623730951, 1.707825127659933, 2.0, 2.29128784747792,
+              2.581988897471611, 2.8722813232690143, 3.1622776601683795])
+        )
+        single_test(
+            SArray([0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1]),
+            SArray([0.0, 0.5, 0.81649658092772603, 1.1180339887498949,
+                1.4142135623730949, 1.707825127659933, 1.9999999999999998,
+                2.2912878474779195])
+        )
+        single_test(
+            SArray([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            SArray([None, 0.0, 0.5, 0.816496580927726, 1.118033988749895,
+                1.4142135623730951, 1.707825127659933, 2.0, 2.29128784747792,
+                2.581988897471611, 2.8722813232690143, 3.1622776601683795])
+        )
+        single_test(
+            SArray([None, 1,   None, 3, None, 5]),
+            SArray([None, 0.0, 0.0, 1.0, 1.0, 1.6329931618554521])
+        )
+
+    def test_cumulative_var(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_var();
+            self.cumulative_aggregate_comparison(out, ans)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_var()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_var()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_var()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1,1], [1], [1]]).cumulative_var()
+        with self.assertRaises(ToolkitError):
+            sa = SArray([[1], [1], [1], [1]]).cumulative_var()
+
+        single_test(
+          SArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+          SArray([0.0, 0.25, 0.6666666666666666, 1.25, 2.0, 2.9166666666666665,
+              4.0, 5.25, 6.666666666666667, 8.25, 10.0])
+        )
+        single_test(
+            SArray([0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1]),
+            SArray( [0.0, 0.25000000000000006, 0.6666666666666666, 1.25,
+                1.9999999999999996, 2.916666666666666, 3.999999999999999,
+                5.249999999999998])
+        )
+        single_test(
+            SArray([None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            SArray([None, 0.0, 0.25, 0.6666666666666666, 1.25, 2.0, 2.9166666666666665,
+                4.0, 5.25, 6.666666666666667, 8.25, 10.0])
+        )
+        single_test(
+            SArray([None, 1,   None, 3, None, 5]),
+            SArray([None, 0.0, 0.0, 1.0, 1.0, 2.6666666666666665])
+        )

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -935,7 +935,7 @@ class SArrayTest(unittest.TestCase):
 
     def _slice_equality_test(self, arr, start=None, stop=None, step=1):
         self.assertEqual(
-                list(arr.subslice(start, stop, step)), 
+                list(arr.subslice(start, stop, step)),
                 list(self._my_subslice(arr,start,stop,step)))
 
     def test_subslice(self):
@@ -956,7 +956,7 @@ class SArrayTest(unittest.TestCase):
         self._slice_equality_test(g, -1, -2, -1);
         self._slice_equality_test(g, None, None, -1);
         self._slice_equality_test(g, -100, -1);
-        
+
         #array slicing
         import array
         g=SArray(range(1,10)).apply(lambda x: array.array('d', range(x)))
@@ -1012,14 +1012,14 @@ class SArrayTest(unittest.TestCase):
             sa3 = sa1.append(sa2)
 
     def test_word_count(self):
-        sa = SArray(["This is someurl http://someurl!!", 
-                     "中文 应该也 行", 
+        sa = SArray(["This is someurl http://someurl!!",
+                     "中文 应该也 行",
                      'Сблъсъкът между'])
-        expected = [{"this": 1, "http://someurl!!": 1, "someurl": 1, "is": 1}, 
-                    {"中文": 1, "应该也": 1, "行": 1}, 
+        expected = [{"this": 1, "http://someurl!!": 1, "someurl": 1, "is": 1},
+                    {"中文": 1, "应该也": 1, "行": 1},
                     {"Сблъсъкът": 1, "между": 1}]
-        expected2 = [{"This": 1, "http://someurl!!": 1, "someurl": 1, "is": 1}, 
-                     {"中文": 1, "应该也": 1, "行": 1}, 
+        expected2 = [{"This": 1, "http://someurl!!": 1, "someurl": 1, "is": 1},
+                     {"中文": 1, "应该也": 1, "行": 1},
                      {"Сблъсъкът": 1, "между": 1}]
         sa1 = sa._count_words()
         self.assertEquals(sa1.dtype(), dict)
@@ -1037,9 +1037,9 @@ class SArrayTest(unittest.TestCase):
     def test_word_count2(self):
         sa = SArray(["This is some url http://www.someurl.com!!", "Should we? Yes, we should."])
         #TODO: Get some weird unicode whitespace in the Chinese and Russian tests
-	expected1 = [{"this": 1, "is": 1, "some": 1, "url": 1, "http://www.someurl.com!!": 1}, 
+	expected1 = [{"this": 1, "is": 1, "some": 1, "url": 1, "http://www.someurl.com!!": 1},
                      {"should": 1, "we?": 1, "we": 1, "yes,": 1, "should.": 1}]
-	expected2 = [{"this is some url http://www.someurl.com": 1}, 
+	expected2 = [{"this is some url http://www.someurl.com": 1},
                      {"should we": 1, " yes": 1, " we should.": 1}]
 	word_counts1 = sa._count_words()
         word_counts2 = sa._count_words(delimiters=["?", "!", ","])
@@ -1497,8 +1497,8 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(ret['X.tmweekday'] , [2, 2, None], int)
 
     def test_datetime_lambda(self):
-        data = [dt.datetime(2013, 5, 7, 10, 4, 10, 109321), 
-                dt.datetime(1902, 10, 21, 10, 34, 10, 991111, 
+        data = [dt.datetime(2013, 5, 7, 10, 4, 10, 109321),
+                dt.datetime(1902, 10, 21, 10, 34, 10, 991111,
                     tzinfo=GMT(1))]
         g=SArray(data)
         gstr=g.apply(lambda x:str(x))
@@ -1600,7 +1600,7 @@ class SArrayTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             sa.str_to_datetime('%m/%d/%Y %L:%M')
 
-        sa = SArray(['2013-05-07T10:04:10', 
+        sa = SArray(['2013-05-07T10:04:10',
             '1902-10-21T10:34:10UTC+05:45'])
         expected = [dt.datetime(2013, 5, 7, 10, 4, 10),
                 dt.datetime(1902, 10, 21, 10, 34, 10).replace(tzinfo=GMT(5.75))]
@@ -1685,4 +1685,58 @@ class SArrayTest(unittest.TestCase):
         X = X.astype(str)
         Y = np.array([str(i) for i in range(100)])
         nptest.assert_array_equal(X.to_numpy(), Y)
+
+    def test_cumulative_sum(self):
+
+        def single_test(src, ans):
+            out = src.cumulative_sum();
+            self.assertEqual(out.size(), ans.size())
+            for i in range(len(out)):
+                import array
+                if type(out[i]) != array.array:
+                  self.assertAlmostEqual(out[i], ans[i])
+                else:
+                  self.assertEqual(len(out[i]), len(ans[i]))
+                  oi = out[i]
+                  ansi = ans[i]
+                  for j in range(len(oi)):
+                      self.assertAlmostEqual(oi, ansi)
+
+        with self.assertRaises(RuntimeError):
+            sa = SArray(["foo"]).cumulative_sum()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], ["foo"]]).cumulative_sum()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([{"bar": 1}]).cumulative_sum()
+        with self.assertRaises(RuntimeError):
+            sa = SArray([[1], [1, 1]]).cumulative_sum()
+
+        single_test(
+          SArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+          SArray([0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55])
+        )
+        single_test(
+            SArray([0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1]),
+            SArray([0.1, 1.2, 3.3, 6.4, 10.5, 15.6, 21.7, 28.8])
+        )
+        single_test(
+            SArray([[11.0, 2.0], [22.0, 1.0], [3.0, 4.0], [4.0, 4.0]]),
+            SArray([[11.0, 2.0], [33.0, 3.0], [36.0, 7.0], [40.0, 11.0]])
+        )
+        single_test(
+            SArray([None, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            SArray([None, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55])
+        )
+        single_test(
+            SArray([None, 1, None, 3, None, 5]),
+            SArray([None, 1, 1, 4, 4, 9])
+        )
+        single_test(
+            SArray([None, [33.0, 3.0], [3.0, 4.0], [4.0, 4.0]]),
+            SArray([None, [33.0, 3.0], [36.0, 7.0], [40.0, 11.0]])
+        )
+        single_test(
+            SArray([None, [33.0, 3.0], None, [4.0, 4.0]]),
+            SArray([None, [33.0, 3.0], [33.0, 3.0], [37.0, 7.0]])
+        )
 

--- a/oss_src/unity/server/unity_server_init.cpp
+++ b/oss_src/unity/server/unity_server_init.cpp
@@ -5,16 +5,18 @@
  * This software may be modified and distributed under the terms
  * of the BSD license. See the LICENSE file for details.
  */
-#include <unity/server/unity_server_init.hpp>
-#include <unity/lib/toolkit_function_registry.hpp>
-#include <unity/toolkits/image/image_fn_export.hpp>
-#include <unity/lib/toolkit_class_registry.hpp>
+#include <unity/extensions/cumulative_aggregates.hpp>
 #include <unity/lib/simple_model.hpp>
+#include <unity/lib/toolkit_class_registry.hpp>
+#include <unity/lib/toolkit_function_registry.hpp>
 #include <unity/lib/unity_odbc_connection.hpp>
+#include <unity/server/unity_server_init.hpp>
+#include <unity/toolkits/image/image_fn_export.hpp>
 
 graphlab::toolkit_function_registry* init_toolkits() {
   graphlab::toolkit_function_registry* g_toolkit_functions = new graphlab::toolkit_function_registry();
   g_toolkit_functions->register_toolkit_function(graphlab::image_util::get_toolkit_function_registration());
+  g_toolkit_functions->register_toolkit_function(graphlab::cumulative_aggregates::get_toolkit_function_registration());
   return g_toolkit_functions;
 }
 

--- a/oss_test/unity/gl_sarray.cxx
+++ b/oss_test/unity/gl_sarray.cxx
@@ -453,6 +453,12 @@ class gl_sarray_test: public CxxTest::TestSuite {
     void test_cumulative_sum() {
       auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
         gl_sarray out = in.cumulative_sum();
+        //for (size_t i = 0; i < out.size(); i++) {
+        //  std::cout << " i   = " << i
+        //            << " in  = " << in[i]
+        //            << " out = " << out[i]
+        //            << " ans = " << ans[i] << std::endl;
+        //}
         _assert_sarray_equals(out, _to_vec(ans));
       }; 
       

--- a/oss_test/unity/gl_sarray.cxx
+++ b/oss_test/unity/gl_sarray.cxx
@@ -451,16 +451,8 @@ class gl_sarray_test: public CxxTest::TestSuite {
     }
 
     void test_cumulative_sum() {
-
-      // Run a single test. 
       auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
         gl_sarray out = in.cumulative_sum();
-        //std::cout << "Testing cumulative sum" << std::endl; 
-        //for (size_t i = 0; i < out.size(); i++) {
-        //  std::cout << "in  = " << in[i] << " " 
-        //            << "out = " << out[i] << " " 
-        //            << "ans = " << ans[i] << " " << std::endl;
-        //}
         _assert_sarray_equals(out, _to_vec(ans));
       }; 
       
@@ -494,7 +486,59 @@ class gl_sarray_test: public CxxTest::TestSuite {
       );
 
     }
-
+    
+    void test_cumulative_avg() {
+      auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
+        gl_sarray out = in.cumulative_avg();
+        _assert_sarray_equals(out, _to_vec(ans));
+      }; 
+      
+      single_test(
+          gl_sarray{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 
+          gl_sarray{0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0} 
+      );
+      single_test(
+          gl_sarray{0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1}, 
+          gl_sarray{0.1, 0.6, 1.1, 1.6, 2.1, 2.6, 3.1, 3.6}
+      );
+      single_test(
+          gl_sarray{{11.0, 22.0}, {33.0, 66.0}, {4.0,   2.0}, {4.0,  2.0}},
+          gl_sarray{{11.0, 22.0}, {22.0, 44.0}, {16.0, 30.0}, {13.0, 23.0}}
+      );
+    }
+    
+    void test_cumulative_min() {
+      auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
+        gl_sarray out = in.cumulative_min();
+        _assert_sarray_equals(out, _to_vec(ans));
+      }; 
+      
+      single_test(
+          gl_sarray{0, 1, 2, 3, 4, 5, -1, 7, 8, -2, 10},
+          gl_sarray{0, 0, 0, 0, 0, 0, -1, -1, -1, -2, -2}
+      );
+      single_test(
+          gl_sarray{7.1, 6.1, 3.1, 3.9, 4.1, 2.1, 2.9, 0.1},
+          gl_sarray{7.1, 6.1, 3.1, 3.1, 3.1, 2.1, 2.1, 0.1}
+      );
+    }
+    
+    void test_cumulative_max() {
+      auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
+        gl_sarray out = in.cumulative_max();
+        _assert_sarray_equals(out, _to_vec(ans));
+      }; 
+      
+      single_test(
+          gl_sarray{0, 1, 0, 3, 5, 4, 1, 7, 6, 2, 10},
+          gl_sarray{0, 1, 1, 3, 5, 5, 5, 7, 7, 7, 10}
+      );
+      single_test(
+          gl_sarray{2.1, 6.1, 3.1, 3.9, 2.1, 8.1, 8.9, 10.1},
+          gl_sarray{2.1, 6.1, 6.1, 6.1, 6.1, 8.1, 8.9, 10.1}
+      );
+    }
+    
   private:
 
     std::vector<flexible_type> _to_vec(gl_sarray sa) {

--- a/oss_test/unity/gl_sarray.cxx
+++ b/oss_test/unity/gl_sarray.cxx
@@ -455,6 +455,12 @@ class gl_sarray_test: public CxxTest::TestSuite {
       // Run a single test. 
       auto single_test = [&](const gl_sarray& in, const gl_sarray& ans) {
         gl_sarray out = in.cumulative_sum();
+        //std::cout << "Testing cumulative sum" << std::endl; 
+        //for (size_t i = 0; i < out.size(); i++) {
+        //  std::cout << "in  = " << in[i] << " " 
+        //            << "out = " << out[i] << " " 
+        //            << "ans = " << ans[i] << " " << std::endl;
+        //}
         _assert_sarray_equals(out, _to_vec(ans));
       }; 
       
@@ -479,23 +485,14 @@ class gl_sarray_test: public CxxTest::TestSuite {
           gl_sarray{FLEX_UNDEFINED, 1, 1, 4, 4, 9} 
       );
       single_test(
-          gl_sarray{FLEX_UNDEFINED, {33.0, 3.0}, {3.0, 4.0}, {4.0, 4.0}},
-          gl_sarray{FLEX_UNDEFINED, {33.0, 3.0}, {36.0, 7.0}, {40.0, 11.0}}
+          gl_sarray{{33.0, 3.0}, FLEX_UNDEFINED, {3.0, 4.0}, {4.0, 4.0}},
+          gl_sarray({{33.0, 3.0}, {33.0, 3.0}, {36.0, 7.0}, {40.0, 11.0}}, flex_type_enum::VECTOR)
       );
       single_test(
-          gl_sarray{FLEX_UNDEFINED, {33.0, 3.0}, FLEX_UNDEFINED, {4.0, 4.0}},
-          gl_sarray{FLEX_UNDEFINED, {33.0, 3.0}, {33.0, 3.0}, {37.0, 7.0}}
+          gl_sarray{{33.0, 3.0}, FLEX_UNDEFINED, FLEX_UNDEFINED, {4.0, 4.0}},
+          gl_sarray({{33.0, 3.0}, {33.0, 3.0}, {33.0, 3.0}, {37.0, 7.0}}, flex_type_enum::VECTOR)
       );
 
-    }
-
-    void test_sarray() {
-      gl_sarray sa{1,2,3,4,5,6};
-
-      auto sa2 = sa.materialize_to_sarray();
-      gl_sarray sa3 = sa2;
-
-      _assert_sarray_equals(sa, _to_vec(sa3));
     }
 
   private:


### PR DESCRIPTION
- Added a cumulative aggregate abstraction.
- Added cumulative sum (serial version).

#### Details


For a cumulative aggregate
   y <- x.cumulative_aggregate(f, w_0)

An abstraction to perform cumulative aggregates which is computed as
   y[i+1], w[i+1] = func(x[i], w[i])

 where w[i] is some arbitary state.

A user can implement cumulative_sum as follows.

```
  auto cumsum_agg = []
    (const flexible_type& v, flexible_type& y) -> flexible_type {
     y += v;
     return y
  };
  out_sa = in_sa.cumulative_aggregate(agg_fn, 0);
```