### PR TITLE
Fix for rare server startup issue

### DIFF
--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -39,7 +39,9 @@ __LOGGER__ = _logging.getLogger(__name__)
 # overuse the same logger so we have one logging config
 root_package_name = __import__(__name__.split('.')[0]).__name__
 logger = logging.getLogger(root_package_name)
-client_log_file = _os.path.join(_tempfile.gettempdir(), (root_package_name + '_client_%d.log' % _time.time()))
+client_log_file = _os.path.join(_tempfile.gettempdir(),
+                                root_package_name +
+                                '_client_%d_%d.log' % (_time.time(), _os.getpid()))
 
 logging.config.dictConfig({
     'version': 1,


### PR DESCRIPTION
Update2:  It's ok to merge since the embeded server PR is built on top of this.
Update: As we remove unity_server, some of the fixes here is no longer valid, and others will be folded the new PR.

The server may fail starting under when either of the following
(rare) conditions is true:

1. when two import happen close together
2. when a previous unity_server process crashed and left behind
ipc file with same pid, which cannot be deleted.

The root causes are both using either pid or timestamp alone
to name important files.

This fix resolve the potential file name conflict by using both
pid and timestamp as process identifier.