### PR TITLE
Improvements to the lambda diagnostics

### DIFF
--- a/oss_src/cppipc/server/comm_server.hpp
+++ b/oss_src/cppipc/server/comm_server.hpp
@@ -190,6 +190,8 @@ class EXPORT comm_server {
    */
   size_t lcg_seed;
 
+  bool comm_server_debug_mode = false;
+
   /**
    * A series of authentication methods to apply to the messages.
    */

--- a/oss_src/lambda/python_api.cpp
+++ b/oss_src/lambda/python_api.cpp
@@ -28,12 +28,13 @@ void init_python(const std::string& root_path) {
   
   Py_Initialize();
 
-  logstream(LOG_INFO) << "Python initialized." << std::endl;
+  LOG_DEBUG_WITH_PID("Python initialized.");
 
   /**
    * Enforce the sys path to be the same as the GLC client's sys path.
    */
   try {
+    LOG_DEBUG_WITH_PID("Importing system modules.");
     python::object sys_path = python::import("sys").attr("path");
     python::object os_environ = python::import("os").attr("environ");
     python::object sys_path_str = os_environ.attr("get")("__GL_SYS_PATH__");
@@ -42,7 +43,7 @@ void init_python(const std::string& root_path) {
     // regular sys.path.
     
     if(sys_path_str != python::object() ) {
-      logstream(LOG_INFO) << "Setting path from __GL_SYS_PATH__." << std::endl;
+      LOG_DEBUG_WITH_PID("__GL_SYS_PATH__ used: " << python::extract<const char*>(sys_path_str));
           
       // Simply doing "sys_path = sys_path_str.attr("split")(":");"
       // does not work as expected.
@@ -60,7 +61,7 @@ void init_python(const std::string& root_path) {
       // Log the path.
       for(int i = 0; i < len(sys_path); ++i) {
         const char* sp = python::extract<const char*>(python::str(sys_path.attr("__getitem__")(i)));
-        logstream(LOG_INFO) << "  sys.path[" << i << "]: " << sp << std::endl; 
+        LOG_DEBUG_WITH_PID("  path[" << i << "]: " << sp);
       }
     }
   } catch (python::error_already_set const& e) {
@@ -78,7 +79,7 @@ void init_python(const std::string& root_path) {
     throw std::current_exception();
   }
 
-  logstream(LOG_INFO) << "Path information set." << std::endl;
+  LOG_DEBUG_WITH_PID("Path information set.");
   
   std::string module_name;
   try {
@@ -88,9 +89,10 @@ void init_python(const std::string& root_path) {
     // we expect to be located in sframe/pylambda_worker or
     // graphlab/pylambda_worker
     curpath = fs::canonical(curpath);
+    LOG_DEBUG_WITH_PID("current path = " << curpath.string());
     module_name = curpath.filename().string();
 
-    logstream(LOG_INFO) << "Module Name is " << module_name << std::endl;
+    LOG_DEBUG_WITH_PID("module_name = " << module_name);
     
     if (module_name != "graphlab" && module_name != "sframe") {
       logstream(LOG_ERROR) << "Module name is " << module_name << std::endl;

--- a/oss_src/logger/CMakeLists.txt
+++ b/oss_src/logger/CMakeLists.txt
@@ -16,5 +16,6 @@ make_library(logger
     boost
     timer
     parallel
+    process
     EXTERNAL_VISIBILITY
   )

--- a/oss_src/unity/python/sframe/_pylambda_worker.py
+++ b/oss_src/unity/python/sframe/_pylambda_worker.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import ctypes
 from ctypes import PyDLL, c_char_p, c_int
 from os.path import split, abspath, join
 from glob import glob
@@ -12,67 +13,60 @@ if __name__ == "__main__":
     else:
         debug_mode = False
 
+    if debug_mode or os.environ.get("GRAPHLAB_LAMBDA_WORKER_DEBUG_MODE") == "1":
+        write_out = sys.stderr
+    else:
+        write_out = sys.stdout
+
     if debug_mode:
         print "PyLambda script called with no IPC information; entering diagnostic mode."
 
     script_path = abspath(sys.modules[__name__].__file__)
     main_dir = split(script_path)[0]
 
-    if debug_mode:
-        print "Script directory: %s." % script_path
-        print "Main program directory: %s." % main_dir
-    else:
-        print "INFO: launching pylamda_worker in directory %s." % main_dir
-        
+    write_out.write("Script directory: %s.\n" % script_path)
+    write_out.write("Main program directory: %s.\n" % main_dir)
+    write_out.flush()
+
+    for s in sys.argv:
+        write_out.write("Lambda worker args: \n  %s\n" % ("\n  ".join(sys.argv)))
+        write_out.flush()
+
     # Handle the different library type extensions
+    pylamda_worker_search_string = join(main_dir, "libpylambda_worker.*")
+    write_out.write("Lambda worker search pattern: %s\n" % pylamda_worker_search_string)
     pylambda_workers = glob(join(main_dir, "libpylambda_worker.*"))
 
-    if debug_mode:
+    write_out.write("Found %d candidade pylambda_worker file(s): \n   %s.\n"
+                    % (len(pylambda_workers), "\n   ".join(pylambda_workers)))
+    write_out.flush()
 
-        error = False
+    if len(pylambda_workers) > 1:
+        write_out.write("WARNING: multiple pylambda worker libraries.\n")
+        write_out.flush()
         
-        print ("Found %d candidade pylambda_worker file(s): \n   %s."
-               % (len(pylambda_workers), "\n   ".join(pylambda_workers)))
+    if len(pylambda_workers) == 0:
+        sys.stderr.write("ERROR: Cannot find pylambda_worker extension library.\n")
+        sys.stderr.flush()
+        sys.exit(202)
 
-        if len(pylambda_workers) > 1:
-            print "WARNING: multiple pylambda worker libraries."
-            error = True
+    write_out.write("INFO: Loading pylambda worker library: %s. \n" % pylambda_workers[0])
+    write_out.flush()
 
-        if len(pylambda_workers) == 0:
-            print "ERROR: Cannot find pylambda_worker extension library."
-            error = True
+    try:
+        pylambda_lib = PyDLL(pylambda_workers[0])
+    except Exception, e:
+        sys.stderr.write("Error loading lambda library %s: %s\n" % (pylambda_workers[0], repr(e)))
+        sys.stderr.flush()
+        sys.exit(203)
 
-        print "Installation Directory Structure: "
-
-        visited_files = []
-
-        def on_error(err):
-            visited_files.append( ("  ERROR", str(err)) )
-
-        for path, dirs, files in os.walk(main_dir, onerror = on_error):
-            for fn in chain(files, dirs):
-                name = join(path, fn)
-                try:
-                    visited_files.append( (name, repr(os.lstat(name))) )
-                except:
-                    visited_files.append( (name, "ERROR calling os.lstat.") )
-
-        def strip_name(n):
-            if n[:len(main_dir)] == main_dir:
-                return "<root>/" + n[len(main_dir):]
-            else:
-                return n
-                
-        print "\n".join( ("  %s: %s" % (strip_name(name), stats))
-                         for name, stats in sorted(visited_files))
-
-        print "INFO: Loading pylambda worker library: ", pylambda_workers[0]
-        
-    
-    pylambda_lib = PyDLL(pylambda_workers[0])
-
-    pylambda_lib.pylambda_worker_main.argtypes = [c_char_p, c_char_p]
-    pylambda_lib.pylambda_worker_main.restype = c_int
+    try:
+        pylambda_lib.pylambda_worker_main.argtypes = [c_char_p, c_char_p]
+        pylambda_lib.pylambda_worker_main.restype = c_int
+    except Exception, e:
+        sys.stderr.write("Error accessing pylambda_worker_main: %s\n" % repr(e))
+        sys.stderr.flush()
+        sys.exit(204)
     
     if not debug_mode:
         # This call only returns after the parent process is done.
@@ -81,5 +75,6 @@ if __name__ == "__main__":
         # This version will print out a bunch of diagnostic information and then exit. 
         result = pylambda_lib.pylambda_worker_main(c_char_p(main_dir), c_char_p("debug"))
 
-    if debug_mode:
-        print "Process exited with code %d." % result
+    write_out.write("Lambda process exited with code %d.\n" % result)
+    write_out.flush()
+    sys.exit(0)


### PR DESCRIPTION
Added in lots of diagnostic information for finding pylambda worker
issues.

- Errors are printed to sys.stderr, so they appear in the console.

- If GRAPHLAB_LAMBDA_WORKER_DEBUG_MODE is set to 1 as an environment
  variable, then all log messages are pushed to stderr and detailed
  progress messages are printed to the console.

Other changes:

- The comm_server only prints out diagnostic information if the
  environment variable GRAPHLAB_COMM_SERVER_DEBUG_MODE is set
  (Otherwise, all lambda worker events and pings are dumped to the
  console.)