### PR TITLE
Fixed a bug in the cumulative variance and stdev code.

### DIFF
--- a/oss_src/sframe/group_aggregate_value.hpp
+++ b/oss_src/sframe/group_aggregate_value.hpp
@@ -119,11 +119,28 @@ class group_aggregate_value {
    */
   virtual inline ~group_aggregate_value() { }
 
+  /**
+   * Override this function for allowing the operator to be easily printed.
+   *
+   * \code
+   *   std::cout << aggregator <<s std::endl; 
+   * \endcode
+   */
+  virtual void print(std::ostream& os) const {
+    os << this->name() << "(value = " << this->emit() << ")";
+  }
+
+
 protected:
   virtual flex_type_enum set_input_type(flex_type_enum type) {
     return type;
   }
 };
+  
+inline std::ostream& operator<<(std::ostream& os, const group_aggregate_value& dt) {
+  dt.print(os);
+  return os;
+}
 
 
 /**

--- a/oss_src/sframe/groupby_aggregate_operators.hpp
+++ b/oss_src/sframe/groupby_aggregate_operators.hpp
@@ -754,10 +754,18 @@ class variance : public group_aggregate_value {
   /// combines two partial counts
   void combine(const group_aggregate_value& other) {
     const variance& _other = dynamic_cast<const variance&>(other);
-    double delta = _other.mean - mean;
-    mean = ((mean * count) + (_other.mean * _other.count)) / (count + _other.count);
-    M2 += _other.M2 + delta * delta * _other.count * count / (count + _other.count);
-    count += _other.count;
+    if (_other.count == 0) {
+      return;
+    } else if (count == 0) {
+      mean = _other.mean;
+      count = _other.count;
+      M2 = _other.M2;
+    } else {
+      double delta = _other.mean - mean;
+      mean = ((mean * count) + (_other.mean * _other.count)) / (count + _other.count);
+      M2 += _other.M2 + delta * delta * _other.count * count / (count + _other.count);
+      count += _other.count;
+    }
   }
 
   /// Emits the count result
@@ -791,11 +799,21 @@ class variance : public group_aggregate_value {
     iarc >> count >> mean >> M2;
   }
 
+  virtual void print(std::ostream& os) const {
+    os << this->name() << "(" 
+       << "value = " << this->emit() << ", " 
+       << "count = " << this->count << ", " 
+       << "mean = "  << this->mean << ", " 
+       << "M2 = "    << this->M2
+       << ")";
+  }
+
  protected:
   size_t count = 0;
   double mean = 0;
   double M2 = 0;
 };
+  
 
 class stdv : public variance {
  public:


### PR DESCRIPTION
The bug occurs during the combining of two aggregates of type variance, or
stdev when either one of them is empty. In other words, the following two
edge cases fail.

  void combine(const group_aggregate_value& other) {
   ...
    if (_other.count == 0) {
      return;
    } else if (count == 0) {
      mean = _other.mean;
      count = _other.count;
      M2 = _other.M2;
    }
   ...

For debugging, I added an << operator for all aggregates.