### PR TITLE
restrict the number of threads used when running tests when num_procs is set

### DIFF
--- a/oss_local_scripts/make_egg.sh
+++ b/oss_local_scripts/make_egg.sh
@@ -71,6 +71,8 @@ fi
 
 if [[ -z "${NUM_PROCS}" ]]; then
   NUM_PROCS=4
+else
+  export OMP_NUM_THREADS=$NUM_PROCS
 fi
 
 TARGET_DIR=${WORKSPACE}/target


### PR DESCRIPTION
This ought to stabilize the travis build (which runs in docker, and so we see much more CPUs than we are actually allocated and we end up using a lot of memory).