### PR TITLE
Change engine start error message for SFrame.

### DIFF
--- a/oss_src/unity/python/sframe/connect/main.py
+++ b/oss_src/unity/python/sframe/connect/main.py
@@ -29,8 +29,8 @@ __LOGGER__ = logging.getLogger(__name__)
 LOCAL_SERVER_TYPE = 'local'
 REMOTE_SERVER_TYPE = 'remote'
 
-ENGINE_START_ERROR_MESSAGE = 'Cannot connect to GraphLab Create engine. ' + \
-    'Contact support@dato.com for help.'
+ENGINE_START_ERROR_MESSAGE = 'Cannot connect to SFrame engine. ' + \
+    'If you believe this to be a bug, check https://github.com/dato-code/SFrame/issues for known issues.'
 
 def _verify_engine_binary(server_bin):
     try:


### PR DESCRIPTION
* There should not be a reference to GraphLab Create (this is the SFrame engine).
* There should not be a reference to Dato support (instead, we should direct users to GitHub since this is an open source project).