### PR TITLE
Set curl timeout options

### DIFF
--- a/oss_src/fileio/CMakeLists.txt
+++ b/oss_src/fileio/CMakeLists.txt
@@ -38,7 +38,7 @@ make_library(fileio
     fileio_constants.cpp
     s3_fstream.cpp
     block_cache.cpp
-    set_curl_ssl_options.cpp
+    set_curl_options.cpp
     dmlcio/s3_filesys.cc
   REQUIRES
     curl openssl libxml2 logger pthread z cancel_serverside_ops globals process util soft_hdfs ${PLATFORM_DEPENDENCIES} network random

--- a/oss_src/fileio/curl_downloader.cpp
+++ b/oss_src/fileio/curl_downloader.cpp
@@ -14,7 +14,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <cppipc/server/cancel_ops.hpp>
-#include <fileio/set_curl_ssl_options.hpp>
+#include <fileio/set_curl_options.hpp>
 extern "C" {
 #include <curl/curl.h>
 }
@@ -49,7 +49,7 @@ int download_url(std::string url, std::string output_file) {
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &download_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)(f));
-    graphlab::fileio::set_ssl_certificate_options(curl);
+    graphlab::fileio::set_curl_options(curl);
     /* Perform the request, res will get the return code */ 
     res = curl_easy_perform(curl);
     /* Check for errors */ 

--- a/oss_src/fileio/dmlcio/s3_filesys.cc
+++ b/oss_src/fileio/dmlcio/s3_filesys.cc
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <ctime>
 #include <sstream>
-#include <fileio/set_curl_ssl_options.hpp>
+#include <fileio/set_curl_options.hpp>
 extern "C" {
 #include <errno.h>
 #include <curl/curl.h>
@@ -25,7 +25,7 @@ extern "C" {
 #include "./s3_filesys.h"
 #include <logger/assertions.hpp>
 
-using graphlab::fileio::set_ssl_certificate_options;
+using graphlab::fileio::set_curl_options;
 
 /*!
  * \brief safely get the beginning address of a vector
@@ -367,7 +367,7 @@ void CURLReadStreamBase::Init(size_t begin_bytes) {
   ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_WRITEDATA, &buffer_) == CURLE_OK);
   ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_HEADERFUNCTION, WriteStringCallback) == CURLE_OK);
   ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_HEADERDATA, &header_) == CURLE_OK);
-  set_ssl_certificate_options(ecurl_);
+  set_curl_options(ecurl_);
   curl_easy_setopt(ecurl_, CURLOPT_NOSIGNAL, 1);
   mcurl_ = curl_multi_init();
   ASSERT_TRUE(curl_multi_add_handle(mcurl_, ecurl_) == CURLM_OK);
@@ -682,7 +682,7 @@ void WriteStream::Run(const std::string &method,
     ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_WRITEDATA, &rdata) == CURLE_OK);  
     ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_WRITEHEADER, WriteSStreamCallback) == CURLE_OK);
     ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_HEADERDATA, &rheader) == CURLE_OK);
-    set_ssl_certificate_options(ecurl_);
+    set_curl_options(ecurl_);
     curl_easy_setopt(ecurl_, CURLOPT_NOSIGNAL, 1);
     if (method == "POST") {
       ASSERT_TRUE(curl_easy_setopt(ecurl_, CURLOPT_POST, 0L) == CURLE_OK);
@@ -798,7 +798,7 @@ void ListObjects(const URI &path,
   ASSERT_TRUE(curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L) == CURLE_OK);
   ASSERT_TRUE(curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteSStreamCallback) == CURLE_OK);
   ASSERT_TRUE(curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result) == CURLE_OK);
-  set_ssl_certificate_options(curl);
+  set_curl_options(curl);
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
   ASSERT_TRUE(curl_easy_perform(curl) == CURLE_OK);
   curl_slist_free_all(slist);

--- a/oss_src/fileio/oss_webstor/wsconn.cpp
+++ b/oss_src/fileio/oss_webstor/wsconn.cpp
@@ -32,7 +32,7 @@
 #include <openssl/hmac.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
-#include <fileio/set_curl_ssl_options.hpp>
+#include <fileio/set_curl_options.hpp>
 #include <algorithm>
 #include <memory>
 #include <fileio/fileio_constants.hpp>
@@ -2532,12 +2532,12 @@ WsConnection::prepare( WsRequest *request, const char *bucketName, const char *k
             } 
             else 
             {
-              graphlab::fileio::set_ssl_certificate_options(m_curl);
+              graphlab::fileio::set_curl_options(m_curl);
             }
         } 
         else 
         {
-          graphlab::fileio::set_ssl_certificate_options(m_curl);
+          graphlab::fileio::set_curl_options(m_curl);
         }
     }
 

--- a/oss_src/fileio/set_curl_options.cpp
+++ b/oss_src/fileio/set_curl_options.cpp
@@ -7,7 +7,7 @@ extern "C" {
 namespace graphlab {
 namespace fileio {
 
-void set_ssl_certificate_options(void* ecurl) {
+void set_curl_options(void* ecurl) {
   using graphlab::fileio::get_alternative_ssl_cert_dir;
   using graphlab::fileio::get_alternative_ssl_cert_file;
   using graphlab::fileio::insecure_ssl_cert_checks;
@@ -21,6 +21,8 @@ void set_ssl_certificate_options(void* ecurl) {
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYPEER, 0l), CURLE_OK);
     ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_SSL_VERIFYHOST, 0l), CURLE_OK);
   }
+  ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_LOW_SPEED_LIMIT, 1l), CURLE_OK);
+  ASSERT_EQ(curl_easy_setopt((CURL*)ecurl, CURLOPT_LOW_SPEED_TIME, 60l), CURLE_OK);
 }
 
 } // fileio

--- a/oss_src/fileio/set_curl_options.hpp
+++ b/oss_src/fileio/set_curl_options.hpp
@@ -6,12 +6,12 @@
  * of the BSD license. See the LICENSE file for details.
  */
 
-#ifndef GRAPHLAB_FILEIO_SET_CURL_SSL_OPTIONS_HPP
-#define GRAPHLAB_FILEIO_SET_CURL_SSL_OPTIONS_HPP
+#ifndef GRAPHLAB_FILEIO_SET_CURL_OPTIONS_HPP
+#define GRAPHLAB_FILEIO_SET_CURL_OPTIONS_HPP
 namespace graphlab {
 namespace fileio {
 
-void set_ssl_certificate_options(void* ecurl);
+void set_curl_options(void* ecurl);
 }
 }
 #endif


### PR DESCRIPTION
This improves robustness of everything which uses curl here.
If the download speed is < 1 byte per second for more than 60 seconds,
we force a timeout + abort.