### PR TITLE
Add support for numpy and pandas datetime objects

### DIFF
--- a/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
@@ -268,6 +268,8 @@ cdef dict _code_by_name_lookup = {
     'datetime' : FT_DATETIME_TYPE + FT_SAFE,
     'date'     : FT_DATETIME_TYPE + FT_SAFE,
     'time'     : FT_DATETIME_TYPE + FT_SAFE,
+    'datetime64': FT_DATETIME_TYPE + FT_SAFE,
+    'Timestamp': FT_DATETIME_TYPE + FT_SAFE,
     'set'      : FT_LIST_TYPE + FT_SAFE,
     'frozenset': FT_LIST_TYPE + FT_SAFE,
     'ndarray'  : FT_BUFFER_TYPE  # Just go by name on this one since it's not always imported
@@ -411,12 +413,19 @@ cdef inline bint flex_type_is_vector_implicit_castable(flex_type_enum ft_type):
 ################################################################################
 
 cdef bint HAS_NUMPY = False
+cdef bint HAS_PANDAS = False
 
 try:
     import numpy as np
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
+
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
 
 cdef vector[flex_type_enum] _dtype_to_flex_enum_lookup = vector[flex_type_enum](128, UNDEFINED)
 
@@ -1122,6 +1131,8 @@ cdef inline tr_listlike_to_ft(flexible_type& ret, _listlike v, flex_type_enum* c
 # Translate DateTime type
 
 cdef inline tr_datetime_to_ft(flexible_type& ret, v):
+    # Restriction from Boost.Date_Time because calculations are inaccurate
+    # before the introduction of the Gregorian calendar
     if(v.year < 1400 or v.year > 10000):
         raise TypeError('Year is out of valid range: 1400..10000')
     if(v.tzinfo != None):
@@ -1129,6 +1140,14 @@ cdef inline tr_datetime_to_ft(flexible_type& ret, v):
         ret.set_date_time((<long long>(calendar.timegm(v.utctimetuple())),offset), v.microsecond)
     else:
         ret.set_date_time((<long long>(calendar.timegm(v.utctimetuple())),EMPTY_TIMEZONE), v.microsecond)
+
+
+cdef inline tr_datetime64_to_ft(flexible_type& ret, v):
+    # Since flexible type datetime only goes down to microseconds, convert to
+    # this. If higher resolution, this will truncate values
+    cdef object as_py_datetime = v.astype('M8[us]').astype('O')
+    as_py_datetime = as_py_datetime.replace(tzinfo=timezone.GMT(0))
+    tr_datetime_to_ft(ret, as_py_datetime)
 
 
 ################################################################################
@@ -1329,8 +1348,17 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
         ret = FLEX_UNDEFINED
         return ret
     elif tr_code == (FT_DATETIME_TYPE + FT_SAFE):
-        tr_datetime_to_ft(ret, datetime(v))
-        return ret
+      if HAS_NUMPY and isinstance(v, np.datetime64):
+          tr_datetime64_to_ft(ret, v)
+      elif HAS_PANDAS and isinstance(v, pd.Timestamp):
+          tr_datetime_to_ft(ret, v.to_datetime())
+      elif isinstance(v, datetime.datetime):
+          tr_datetime_to_ft(ret, v)
+      else:
+          # This should catch only datetime.date, since the check for
+          # datetime.datetime is before it
+          tr_datetime_to_ft(ret, datetime.datetime(v.year, v.month, v.day))
+      return ret
     elif tr_code == (FT_IMAGE_TYPE + FT_SAFE):
         if type(v) != _image_type:
             raise TypeError("Cannot interpret type '" + str(type(v)) + "' as graphlab.Image type.")

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -2552,3 +2552,70 @@ class SArrayTest(unittest.TestCase):
             SArray([None, 1,   None, 3, None, 5]),
             SArray([None, 0.0, 0.0, 1.0, 1.0, 2.6666666666666665])
         )
+
+    def test_numpy_datetime64(self):
+        # Make all datetimes naive
+        expected = [i.replace(tzinfo=GMT(0.0)) \
+                if i is not None and i.tzinfo is None else i for i in self.datetime_data]
+
+        # A regular list
+        iso_str_list = [np.datetime64('2013-05-07T10:04:10Z'),
+                        np.datetime64('1902-10-21T10:34:10Z'),
+                        None]
+        sa = SArray(iso_str_list)
+        self.__test_equal(sa,expected,dt.datetime)
+
+        # A numpy array
+        np_ary = np.array(iso_str_list)
+        sa = SArray(np_ary)
+        self.__test_equal(sa,expected,dt.datetime)
+
+        ### Every possible type of datetime64
+        test_str = '1969-12-31T23:59:56Z'
+        available_time_units = ['h','m','s','ms','us','ns','ps','fs','as']
+        expected = [dt.datetime(1969,12,31,23,59,56,tzinfo=GMT(0.0)) for i in range(7)]
+        expected.insert(0,dt.datetime(1969,12,31,23,59,0,tzinfo=GMT(0.0)))
+        expected.insert(0,dt.datetime(1969,12,31,23,0,0,tzinfo=GMT(0.0)))
+        for i in range(len(available_time_units)):
+            sa = SArray([np.datetime64(test_str,available_time_units[i])])
+            self.__test_equal(sa,[expected[i]],dt.datetime)
+
+        test_str = '1908-06-01'
+        available_date_units = ['Y','M','W','D']
+        expected = [dt.datetime(1908,6,1,0,0,0,tzinfo=GMT(0.0)) for i in range(4)]
+        expected[2] = dt.datetime(1908,5,28,0,0,0,tzinfo=GMT(0.0)) # weeks start on Thursday?
+        expected[0] = dt.datetime(1908,1,1,0,0,0,tzinfo=GMT(0.0))
+        for i in range(len(available_date_units)):
+            sa = SArray([np.datetime64(test_str,available_date_units[i])])
+            self.__test_equal(sa,[expected[i]],dt.datetime)
+
+        # Daylight savings time (Just to be safe. datetime64 deals in UTC, and
+        # we store times in UTC by default, so this shouldn't affect anything)
+        sa = SArray([np.datetime64('2015-03-08T02:38:00-08')])
+        expected = [dt.datetime(2015,3,8,10,38,tzinfo=GMT(0.0))]
+        self.__test_equal(sa, expected, dt.datetime)
+
+        # timezone considerations
+        sa = SArray([np.datetime64('2016-01-01T05:45:00+0545')])
+        expected = [dt.datetime(2016,1,1,0,0,0,tzinfo=GMT(0.0))]
+        self.__test_equal(sa, expected, dt.datetime)
+
+        ### Out of our datetime range
+        with self.assertRaises(TypeError):
+            sa = SArray([np.datetime64('1066-10-14T09:00:00Z')])
+
+    def test_pandas_timestamp(self):
+        iso_str_list = [pd.Timestamp('2013-05-07T10:04:10'),
+                        pd.Timestamp('1902-10-21T10:34:10Z'),
+                        None]
+        sa = SArray(iso_str_list)
+        self.__test_equal(sa,self.datetime_data,dt.datetime)
+
+        sa = SArray([pd.Timestamp('2015-03-08T02:38:00-08')])
+        expected = [dt.datetime(2015,3,8,2,38,tzinfo=GMT(-8.0))]
+        self.__test_equal(sa, expected, dt.datetime)
+
+        sa = SArray([pd.Timestamp('2016-01-01 05:45:00', tz=GMT(5.75))])
+        expected =  [dt.datetime(2016,1,1,5,45,0,tzinfo=GMT(5.75))]
+        self.__test_equal(sa, expected, dt.datetime)
+


### PR DESCRIPTION
This adds support for numpy.datetime64 and pandas.Timestamp.

Conversion from numpy.datetime64 results in a datetime.datetime with timezone set explicitly to UTC, since numpy stores its info in UTC and does not keep track of timezones.

Conversion from pandas.Timestamp uses that type's own "to_datetime" method.