### PR TITLE
Fix for a memory leak when creating empty sframe or sarray

### DIFF
--- a/oss_src/sframe/sarray.hpp
+++ b/oss_src/sframe/sarray.hpp
@@ -587,7 +587,7 @@ class sarray : public swriter_base<swriter_impl::output_iterator<T> > {
     delete writer;
     writing = false;
 
-    if (size() > 0) keep_array_file_ref();
+    keep_array_file_ref();
   }
 
   /**

--- a/oss_src/sframe/sframe.cpp
+++ b/oss_src/sframe/sframe.cpp
@@ -630,6 +630,12 @@ void sframe::close() {
   } else {
     index_info.nrows = 0;
   }
+
+  if (!group_index.group_index_file.empty()) {
+    index_file_handle.push_back(
+        fileio::file_handle_pool::get_instance().register_file(
+            group_index.group_index_file));
+  }
   group_writer.reset();
   write_sframe_index_file(index_file, index_info);
   inited = true;
@@ -640,7 +646,7 @@ void sframe::close() {
     columns[i]->open_for_read(group_index.columns[i]);
   }
   // we can now read.
-  if (index_info.nrows > 0) keep_array_file_ref();
+  keep_array_file_ref();
 }
 
 

--- a/oss_src/unity/lib/unity_sframe.cpp
+++ b/oss_src/unity/lib/unity_sframe.cpp
@@ -37,18 +37,24 @@ namespace graphlab {
 
 using namespace graphlab::query_eval;
 
-unity_sframe::unity_sframe() {
+static std::shared_ptr<sframe> get_empty_sframe() {
   // make empty sframe and keep it around, reusing it whenever
-  // I need an empty sframe
-  static std::shared_ptr<sframe> sf;
+  // I need an empty sframe. We are intentionally leaking this object.
+  // Otherwise the termination of this will race against the cleanup of the 
+  // cache files.
+  static std::shared_ptr<sframe>* sf = nullptr;
   static graphlab::mutex static_sf_lock;
   std::lock_guard<graphlab::mutex> guard(static_sf_lock);
   if (sf == nullptr) {
-    sf = std::make_shared<sframe>();
-    sf->open_for_write({}, {}, "", 1);
-    sf->close();
+    sf = new std::shared_ptr<sframe>();
+    (*sf) = std::make_shared<sframe>();
+    (*sf)->open_for_write({}, {}, "", 1);
+    (*sf)->close();
   }
-  this->set_sframe(sf);
+  return *sf;
+}
+unity_sframe::unity_sframe() {
+  this->set_sframe(get_empty_sframe());
 }
 
 unity_sframe::~unity_sframe() { clear(); }


### PR DESCRIPTION
For for a memory leak when creating empty SFrame (no rows or no columns) and empty sarrays (no rows).

In addition, as an optimization we maintain one empty SArray and one empty SFrame. But there is an annoying termination race issue between 
 - clearing of the cache files
 - deletion of the empty SArray/SFrame

A proper solution is non-trivial. At the moment the cleanest solution is simply to leak the empty SArray / empty SFrame.