### PR TITLE
Random SFrame generation for testing and benchmarking

### DIFF
--- a/oss_src/unity/extensions/CMakeLists.txt
+++ b/oss_src/unity/extensions/CMakeLists.txt
@@ -8,6 +8,7 @@ endmacro()
 #----------------------------
 make_extension(internal_demo SOURCES internal_demo.cpp)
 make_extension(additional_sframe_utilities SOURCES additional_sframe_utilities.cpp)
+make_extension(random_sframe_generation SOURCES random_sframe_generation.cpp)
 make_extension(grouped_sframe SOURCES grouped_sframe.cpp)
 
 #----------------------------

--- a/oss_src/unity/extensions/random_sframe_generation.cpp
+++ b/oss_src/unity/extensions/random_sframe_generation.cpp
@@ -1,0 +1,476 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#include <unity/extensions/random_sframe_generation.hpp>
+#include <util/cityhash_gl.hpp>
+#include <unity/lib/gl_sframe.hpp>
+#include <sframe/sframe.hpp>
+#include <unity/lib/toolkit_function_macros.hpp>
+#include <vector>
+
+using namespace graphlab; 
+
+/**  Creates a random SFrame for testing purposes.  The
+ *  column_types gives the types of the column.
+ *
+ *  \param[in] n_rows The number of observations to run the timing on.
+ *  \param[in] random_seed Seed used to determine the running. 
+ *  \param[in] column_types A string with each character denoting
+ *  one type of column.  The legend is as follows:
+ *
+ *     n:  numeric column, uniform 0-1 distribution. 
+ *     N:  numeric column, uniform 0-1 distribution, 1% NaNs.
+ *     r:  numeric column, uniform -100 to 100 distribution. 
+ *     R:  numeric column, uniform -10000 to 10000 distribution, 1% NaNs.
+ *     b:  binary integer column, uniform distribution
+ *     z:  integer column with random integers between 1 and 10.
+ *     Z:  integer column with random integers between 1 and 100.
+ *     s:  categorical string column with 10 different unique short strings. 
+ *     S:  categorical string column with 100 different unique short strings. 
+ *     c:  categorical column with short string keys and 1000 unique values, triangle distribution.
+ *     C:  categorical column with short string keys and 100000 unique values, triangle distribution.
+ *     x:  categorical column with 128bit hex hashes and 1000 unique values. 
+ *     X:  categorical column with 256bit hex hashes and 100000 unique values. 
+ *     h:  column with unique 128bit hex hashes.
+ *     H:  column with unique 256bit hex hashes.
+ *
+ *     l:  categorical list with between 0 and 10 unique integer elements from a pool of 100 unique values. 
+ *     L:  categorical list with between 0 and 100 unique integer elements from a pool of 1000 unique values.
+ *     M:  categorical list with between 0 and 10 unique string elements from a pool of 100 unique values. 
+ *     m:  categorical list with between 0 and 100 unique string elements from a pool of 1000 unique values.
+ *
+ *     v:  numeric vector with 10 elements and uniform 0-1 elements.
+ *     V:  numeric vector with 1000 elements and uniform 0-1 elements.
+ *     w:  numeric vector with 10 elements and uniform 0-1 elements, 1% NANs.
+ *     W:  numeric vector with 1000 elements and uniform 0-1 elements, 1% NANs.
+ * 
+ *     d: dictionary with with between 0 and 10 string keys from a
+ *        pool of 100 unique keys, and random 0-1 values.
+ *
+ *     D: dictionary with with between 0 and 100 string keys from a
+ *        pool of 1000 unique keys, and random 0-1 values.
+ * 
+ * Target Generation
+ * -----------------
+ *  
+ * If generate_target is true, then the target value is a linear
+ * combination of the features chosen for each row plus uniform noise.
+ * 
+ * - For each numeric and vector columns, each value, with the range
+ *   scaled to [-0.5, 0.5] (so r and R type values affect the target just
+ *   as much as n an N), is added to the target value.  NaNs are ignored.
+ * 
+ * - For each categorical or string values, it is hash-mapped to a lookup
+ *   table of 512 randomly chosen values, each in [-0.5, 0.5], and the
+ *   result is added to the target.
+ * 
+ * - For dictionary columns, the keys are treated as adding a categorical
+ *   value and the values are treated as adding a numeric value. 
+ * 
+ * At the end, a uniform random value is added to the target in the
+ * range [(max_target - min_target) * noise_level], where max_target
+ * and min_target are the maximum and minimum target values generated
+ * by the above process.
+ *
+ * The final target values are then scaled to [0, 1]. 
+ *  
+ */
+gl_sframe _generate_random_sframe(size_t n_rows, std::string column_types,
+                                  size_t _random_seed, bool generate_target, double noise_level) {
+
+  ASSERT_MSG(n_rows > 0, "Number of rows must be greater than 0.");
+
+  sframe data;
+
+  size_t num_columns = column_types.size();
+  size_t n_threads = thread::cpu_count();
+
+  std::vector<std::string> names;
+  std::vector<flex_type_enum> types;
+
+  names.resize(column_types.size());
+  types.resize(column_types.size());
+
+  ////////////////////////////////////////////////////////////////////////////////
+  //  Set up the information lookups for each of the columns: type,
+  //  whether it's categorical, and the description to print.
+  //
+  for(size_t c_idx = 0; c_idx < num_columns; c_idx++){
+
+    names[c_idx] = std::string("X") + std::to_string(c_idx + 1) + "-" + column_types[c_idx];
+
+    switch(column_types[c_idx]) {
+      case 'n':
+      case 'N':
+      case 'r':
+      case 'R':
+        types[c_idx] = flex_type_enum::FLOAT;
+        break;
+
+      case 'b':
+      case 'z':
+      case 'Z':
+        types[c_idx] = flex_type_enum::INTEGER;
+        break;
+
+      case 'c':
+      case 'C':
+      case 's':
+      case 'S':
+      case 'x':
+      case 'X':
+      case 'h':
+      case 'H':
+        types[c_idx] = flex_type_enum::STRING;
+        break;
+
+      case 'v':
+      case 'V':
+        types[c_idx] = flex_type_enum::VECTOR;
+        break;
+
+      case 'l':
+      case 'L':
+      case 'm':
+      case 'M':
+        types[c_idx] = flex_type_enum::LIST;
+        break;
+
+      case 'd':
+      case 'D':
+        types[c_idx] = flex_type_enum::DICT;
+        break;
+
+      default:
+        std::string msg = (std::string("Column type ") + column_types[c_idx] + " not recognized.");
+        ASSERT_MSG(false, msg.c_str());
+        break; 
+
+    }
+  }
+
+  size_t target_column = names.size(); 
+  if(generate_target) {
+    names.push_back("target");
+    types.push_back(flex_type_enum::INTEGER); // Changed to float later on. 
+  }
+  
+  ////////////////////////////////////////////////////////////////////////////////
+  // Create the sframe with each of the columns as determined above.
+
+  data.open_for_write(names, types, "", n_threads);
+
+  static const size_t n_bins = 256;
+  static const size_t n_target_precision = (1 << 24);
+  
+  // Hash it once for a bit of extra random_ness. 
+  uint64_t random_seed = hash64(_random_seed);
+
+  std::vector<flex_int> target_adjust;
+
+  if(generate_target) {
+    target_adjust.resize(n_bins);
+    size_t c = 0; 
+    for(flex_int & x : target_adjust) {
+      x = long(hash64(++c, random_seed) % n_target_precision) - (n_target_precision/2);
+    }
+  }
+
+  // Accumulators for the min and max target values for easy scaling later. 
+  std::vector<flex_int> target_min_v(n_threads, 0);
+  std::vector<flex_int> target_max_v(n_threads, 0);
+  
+  in_parallel([&](size_t thread_idx, size_t num_segments) {
+
+    auto it_out = data.get_output_iterator(thread_idx);
+
+    std::vector<flexible_type> row(column_types.size() + (generate_target ? 1 : 0));
+
+    size_t start_idx = (thread_idx * n_rows) / num_segments;
+    size_t end_idx = ((thread_idx + 1) * n_rows) / num_segments;
+
+    for(size_t i = start_idx; i < end_idx; ++i, ++it_out) {
+      /** Base random number generators.  If there is a target
+       *  present, then these also affect the target 
+       */ 
+      size_t _rng_state = hash64(i, random_seed);
+      
+      // Start the target seed for this row. 
+      flex_int target_value = 0;
+
+      // Go through the columns, randomly filling each. 
+      for(size_t c_idx = 0; c_idx < column_types.size(); ++c_idx) {
+        
+        auto rng_int = [&](size_t lb, size_t ub) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          size_t z = size_t(hash64(++_rng_state) % (ub - lb + 1));
+          if(generate_target) {
+            target_value += target_adjust[z % target_adjust.size()];
+          }
+          return z + lb;
+        };
+
+        auto rng_dbl = [&](double lb, double ub) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+
+          double v01 = double(hash64(++_rng_state)) / std::numeric_limits<uint64_t>::max();
+          if(generate_target) {
+            target_value += long(std::round(n_target_precision * v01) - (n_target_precision/2));
+          }
+          return lb + (ub - lb) * v01;
+        };
+
+        /** Composite random number generators. 
+         */ 
+        auto rng_dbl_nan = [&](double lb, double ub) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          return (hash64(++_rng_state) < (std::numeric_limits<uint64_t>::max() / 100)
+                  ? NAN : rng_dbl(lb,ub));
+        };
+        
+        // Generate a random hex string of the form "C-###"
+        auto rng_str = [&](size_t pool_size) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          // Everything is deterministic from a random set (1, ...,
+          // pool_size), allowing for limiting the number of random things available
+          char ret[16];
+          std::fill(ret, ret + 16, '\0');
+          snprintf(&ret[0], 16, "C-%ld", rng_int(0, pool_size-1));
+          return std::string(ret);
+        };
+
+        // Generate a random hex key
+        auto rng_hex = [&](size_t length, size_t pool_size) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) { 
+          
+          static const char charset[] = "0123456789abcdef";
+
+          // Everything is deterministic from a random set (1, ...,
+          // pool_size), allowing for limiting the number of random things available
+          size_t x = hash64(++_rng_state) % pool_size;
+  
+          std::string ret;
+          ret.reserve(length);
+      
+          for(size_t i = 0; i < length; i += 8) {
+            size_t number = x;
+
+            for(size_t j = 0; j < 16; ++j) {
+              ret.push_back(charset[number & 0xF]);
+              number >>= 4;
+              if(ret.size() >= length) {
+                return ret;
+              }
+            }
+    
+            x = hash64(x);
+          }
+  
+          return ret; 
+        };
+
+        // Generate a random list
+        auto rng_list = [&](size_t max_size, size_t key_pool_size, bool string_values) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN)  {
+          size_t s = rng_int(0,max_size);
+          flex_list v(s);
+          for(flexible_type& f : v) {
+            if(string_values) {
+              f = rng_str(key_pool_size);
+            } else {
+              f = rng_int(1, key_pool_size);
+            }
+          }
+
+          return v;
+        };
+        
+        // Generate a random vector
+        auto rng_vec = [&](size_t s) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          flex_vec v(s);
+          for(double& f : v) f = rng_dbl(0,1);
+          return v;
+        };
+
+        // Generate a random vector
+        auto rng_vec_nan = [&](size_t s) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          flex_vec v(s);
+          for(double& f : v) f = rng_dbl_nan(0,1);
+          return v;
+        };
+        
+        // Generate a random dictionary
+        auto rng_dict = [&](size_t max_size, size_t key_pool_size) GL_GCC_ONLY(GL_HOT_INLINE_FLATTEN) {
+          std::map<size_t,double> m;
+
+          size_t s = rng_int(0, max_size); 
+          
+          for(size_t i = 0; i < s; ++i) {
+            size_t index = rng_int(1, key_pool_size); 
+            double value = rng_dbl(0, 1);
+            m[index] = value;
+          }
+
+          flex_dict d(m.size());
+          char key[16];
+          
+          for(const auto& p : m) {
+            snprintf(key, 15, "K-%ld", p.first); 
+            d.push_back( {flex_string(key), p.second} );
+          }
+
+          return d;
+        };
+
+        // Based on the column output type, write it out        
+        switch(column_types[c_idx]){
+
+          case 'n': { row[c_idx] = rng_dbl(0,1);               break; }
+          case 'N': { row[c_idx] = rng_dbl_nan(0,1);           break; }
+          case 'r': { row[c_idx] = rng_dbl(-100,100);          break; }
+          case 'R': { row[c_idx] = rng_dbl_nan(-1000,1000);    break; }
+          case 'b': { row[c_idx] = rng_int(0, 1);              break; }
+          case 'z': { row[c_idx] = rng_int(1, 10);             break; }
+          case 'Z': { row[c_idx] = rng_int(1, 100);            break; }
+          case 's': { row[c_idx] = rng_str(10);                break; }
+          case 'S': { row[c_idx] = rng_str(100);               break; }
+          case 'c': { row[c_idx] = rng_str(1000);              break; }
+          case 'C': { row[c_idx] = rng_str(100000);            break; }
+          case 'x': { row[c_idx] = rng_hex(32, 1000);          break; }
+          case 'X': { row[c_idx] = rng_hex(64, 100000);        break; }
+          case 'h': { row[c_idx] = rng_hex(32, size_t(-1));    break; }
+          case 'H': { row[c_idx] = rng_hex(64, size_t(-1));    break; }
+          case 'v': { row[c_idx] = rng_vec(10);                break; }
+          case 'V': { row[c_idx] = rng_vec(100);               break; }
+          case 'w': { row[c_idx] = rng_vec_nan(10);            break; }
+          case 'W': { row[c_idx] = rng_vec_nan(100);           break; }
+          case 'l': { row[c_idx] = rng_list(10, 100, false);   break; }
+          case 'L': { row[c_idx] = rng_list(100, 1000, false); break; }
+          case 'm': { row[c_idx] = rng_list(10, 100, true);    break; }
+          case 'M': { row[c_idx] = rng_list(100, 1000, true);  break; }
+          case 'd': { row[c_idx] = rng_dict(10, 100);          break; }
+          case 'D': { row[c_idx] = rng_dict(100, 1000);        break; }
+            
+          default:
+            std::string msg = (std::string("Column type ") + column_types[c_idx] + " not recognized.");
+            ASSERT_MSG(false, msg.c_str());
+        }
+      }
+
+      if(generate_target) {
+        row[target_column] = target_value;
+        target_min_v[thread_idx] = std::min(target_min_v[thread_idx], target_value); 
+        target_max_v[thread_idx] = std::max(target_max_v[thread_idx], target_value); 
+      }
+      
+      *it_out = row;
+    }
+    });
+
+  data.close();
+  
+  gl_sframe ret_sf(data);
+  
+  if(generate_target) {
+    flex_int target_min = *std::min_element(target_min_v.begin(), target_min_v.end());
+    flex_int target_max = *std::max_element(target_max_v.begin(), target_max_v.end());
+
+    // To prevent divide by zeros
+    target_max = std::max(target_min + 1, target_max);
+
+    long noise_level_int = long(std::ceil( (n_target_precision) * noise_level));
+
+    // Add in the noise and map things to [0,1]
+    ret_sf["target"] = ret_sf["target"].apply(
+        [=](const flexible_type& x) -> flexible_type {
+          flex_int v = x.get<flex_int>();
+
+          DASSERT_LE(v, target_max);
+          DASSERT_GE(v, target_min);
+            
+          if(noise_level_int != 0) {
+            flex_int ub = std::min(target_max, v + noise_level_int);
+            flex_int lb = std::max(target_min, v - noise_level_int);
+            v = (hash64(v, random_seed) % (ub - lb + 1) + lb);
+            DASSERT_LE(v, target_max);
+            DASSERT_GE(v, target_min);
+          }
+
+          flex_float res = (flex_float(v - target_min) / (target_max - target_min));
+          DASSERT_LE(res, 1.0);
+          DASSERT_GE(res, 0.0);
+          return res;
+          
+        }, flex_type_enum::FLOAT, false);
+  }
+  
+  return ret_sf;
+}
+
+/**  Creates a random SFrame for testing purposes, with num_rows,
+ *   column_types, and random_seed the same as _generate_random_sframe
+ *   above.  In addition, an integer categorical target column is
+ *   added by binning the output of the numerical target column given
+ *   in _generate_random_sframe.
+ *
+ *   The target column, called "target", is an integer value that
+ *   represents the binning of the output of a noisy linear function
+ *   of the chosen random variables into `num_bins_scale_factor *
+ *   num_classes` bins, shuffled, and then each bin is mapped to
+ *   num_classes values.  This means that some non-linearity is
+ *   present if num_bins_scale_factor > 1, but many patterns can be
+ *   learned. For details on how the random linear value is chosen,
+ *   see the documentation on
+ *   :ref:`generate_random_regression_sframe`.
+ *
+ *   The noise_level is handled identically to
+ *   _generate_random_sframe, except that noise_level is divided by
+ *   the number of bins.  Thus it here represents the probability that
+ *   a class will be mapped to the wrong neighboring bin.
+ */
+gl_sframe _generate_random_classification_sframe(size_t n_rows, std::string column_types,
+                                                 size_t random_seed, size_t num_classes,
+                                                 size_t num_extra_class_bins,
+                                                 double misclassification_spread) {
+
+  // Set up the bin mapping. 
+  size_t n_bins = num_classes + num_extra_class_bins;
+  std::vector<size_t> bin_to_class_map(n_bins);
+
+  gl_sframe X = _generate_random_sframe(n_rows, column_types, random_seed, true,
+                                        misclassification_spread / n_bins);
+  
+  random::seed(random_seed);
+  
+  for(size_t i = 0; i < num_classes; ++i) {
+    bin_to_class_map[i] = i;
+  }
+  
+  for(size_t i = num_classes; i < n_bins; ++i) {
+    bin_to_class_map[i] = random::fast_uniform<size_t>(0, num_classes - 1);
+  }
+
+  random::shuffle(bin_to_class_map);
+  
+  std::function<flexible_type(const flexible_type&)> classify
+      = [=](const flexible_type& x) {
+    size_t b = std::min<flex_int>(n_bins - 1,
+        std::max<flex_int>(0,
+            flex_int(std::floor(x.get<flex_float>() * n_bins))));
+    
+    return bin_to_class_map[b];
+  };
+      
+  X["target"] = X["target"].apply(classify, flex_type_enum::INTEGER, false); 
+
+  return X;
+}
+    
+BEGIN_FUNCTION_REGISTRATION
+REGISTER_FUNCTION(_generate_random_sframe,
+                  "num_rows", "column_codes", "random_seed", "generate_target", "noise_level");
+
+REGISTER_FUNCTION(_generate_random_classification_sframe,
+                  "num_rows", "column_codes", "random_seed", "num_classes",
+                  "num_extra_class_bins", "misclassification_spread");
+
+END_FUNCTION_REGISTRATION
+

--- a/oss_src/unity/extensions/random_sframe_generation.hpp
+++ b/oss_src/unity/extensions/random_sframe_generation.hpp
@@ -1,0 +1,14 @@
+#ifndef GRAPHLAB_UNITY_RANDOM_SFRAME_GENERATION_H_
+#define GRAPHLAB_UNITY_RANDOM_SFRAME_GENERATION_H_
+
+#include <unity/lib/gl_sarray.hpp>
+#include <string>
+
+graphlab::gl_sframe _generate_random_sframe(size_t num_rows, std::string column_types,
+                                            size_t random_seed, bool generate_target, double noise_level);
+
+graphlab::gl_sframe _generate_random_classification_sframe(size_t n_rows, std::string column_types,
+                                                           size_t _random_seed, size_t num_classes,
+                                                           size_t num_extra_class_bins, double noise_level);
+
+#endif /* GRAPHLAB_UNITY_RANDOM_SFRAME_GENERATION_H_ */

--- a/oss_src/unity/python/sframe/test/test_sframe_generation.py
+++ b/oss_src/unity/python/sframe/test/test_sframe_generation.py
@@ -1,0 +1,76 @@
+'''
+Copyright (C) 2016 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+from ..util import generate_random_sframe
+from ..util import generate_random_regression_sframe
+from ..util import generate_random_classification_sframe
+
+import unittest
+import array
+
+class SFrameGeneration(unittest.TestCase):
+    
+    def test_data_types(self):
+        column_codes = {
+            'n': float,
+            'N': float,
+            'r': float,
+            'R': float,
+            'b': int, 
+            'z': int, 
+            'Z': int,
+            'c': str,
+            'C': str,
+            's': str,
+            'S': str,
+            'x': str,
+            'X': str,
+            'h': str,
+            'H': str,
+            'v': array.array,
+            'V': array.array,
+            'l': list,
+            'L': list,
+            'm': list,
+            'M': list,
+            'd': dict,
+            'D': dict} 
+                        
+        test_codes = ''.join(column_codes.keys())
+        X = generate_random_sframe(10, test_codes)
+        column_names = X.column_names()
+
+        for c, n in zip(test_codes, column_names):
+            self.assertEquals(X[n].dtype(), column_codes[c])
+
+    def test_regression_result(self):
+
+        for L in range(1, 10):
+            X = generate_random_regression_sframe(100, 'n' * L, target_noise_level=0)
+            X["target_2"] = X.apply(lambda d: sum(v for k, v in d.iteritems() if k != "target"))
+            X["target_2"] = X["target_2"] - X["target_2"].min()
+            X["target_2"] = X["target_2"] / X["target_2"].max()
+            
+            self.assertAlmostEqual( (X["target_2"] - X["target"]).std(), 0, delta = 0.001)
+
+    def test_classification_result(self):
+
+        for L in range(1, 10):
+            X = generate_random_classification_sframe(100, 'n' * L, misclassification_spread=0,
+                                                      num_classes = 2, num_extra_class_bins = 0)
+            X["target_2"] = X.apply(lambda d: sum(v for k, v in d.iteritems() if k != "target"))
+            X["target_2"] = X["target_2"] - X["target_2"].min()
+            X["target_2"] = X["target_2"] / X["target_2"].max()
+
+            x_1 = X["target_2"][X["target"] == 0]
+            x_2 = X["target_2"][X["target"] == 1]
+
+            self.assertTrue((x_1.max() - 1e-4 <= x_2.min() + 1e-4)
+                            or (x_2.max() - 1e-4 <= x_1.min() + 1e-4))
+            
+
+

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -29,6 +29,10 @@ import time as _time
 import logging as _logging
 import sys as _sys
 
+from sframe_generation import generate_random_sframe
+from sframe_generation import generate_random_regression_sframe
+from sframe_generation import generate_random_classification_sframe
+
 def _i_am_a_lambda_worker():
     if _re.match(".*lambda_worker.*", _sys.argv[0]) is not None:
         return True

--- a/oss_src/unity/python/sframe/util/sframe_generation.py
+++ b/oss_src/unity/python/sframe/util/sframe_generation.py
@@ -1,0 +1,248 @@
+"""
+Wraps utilities for generating random sframes for testing and
+benchmarking.
+"""
+def generate_random_sframe(num_rows, column_codes, random_seed = 0):
+    """
+    Creates a random SFrame with `num_rows` rows and randomly
+    generated column types determined by `column_codes`.  The output
+    SFrame is deterministic based on `random_seed`.
+ 
+     `column_types` is a string with each character denoting one type
+     of column, with the output SFrame having one column for each
+     character in the string.  The legend is as follows:
+
+        n:  numeric column, uniform 0-1 distribution. 
+        N:  numeric column, uniform 0-1 distribution, 1% NaNs.
+        r:  numeric column, uniform -100 to 100 distribution. 
+        R:  numeric column, uniform -10000 to 10000 distribution, 1% NaNs.
+        b:  binary integer column, uniform distribution
+        z:  integer column with random integers between 1 and 10.
+        Z:  integer column with random integers between 1 and 100.
+        s:  categorical string column with 10 different unique short strings. 
+        S:  categorical string column with 100 different unique short strings. 
+        c:  categorical column with short string keys and 1000 unique values, triangle distribution.
+        C:  categorical column with short string keys and 100000 unique values, triangle distribution.
+        x:  categorical column with 128bit hex hashes and 1000 unique values. 
+        X:  categorical column with 256bit hex hashes and 100000 unique values. 
+        h:  column with unique 128bit hex hashes.
+        H:  column with unique 256bit hex hashes.
+
+        l:  categorical list with between 0 and 10 unique integer elements from a pool of 100 unique values. 
+        L:  categorical list with between 0 and 100 unique integer elements from a pool of 1000 unique values.
+        M:  categorical list with between 0 and 10 unique string elements from a pool of 100 unique values. 
+        m:  categorical list with between 0 and 100 unique string elements from a pool of 1000 unique values.
+
+        v:  numeric vector with 10 elements and uniform 0-1 elements.
+        V:  numeric vector with 1000 elements and uniform 0-1 elements.
+        w:  numeric vector with 10 elements and uniform 0-1 elements, 1% NANs.
+        W:  numeric vector with 1000 elements and uniform 0-1 elements, 1% NANs.
+
+        d: dictionary with with between 0 and 10 string keys from a
+           pool of 100 unique keys, and random 0-1 values.
+
+        D: dictionary with with between 0 and 100 string keys from a
+           pool of 1000 unique keys, and random 0-1 values.
+
+    For example::
+
+      X = generate_random_sframe(10, 'nnv')
+
+    will generate a 10 row SFrame with 2 floating point columns and
+    one column of length 10 vectors.
+    """
+
+    from ..extensions import _generate_random_sframe
+
+    assert isinstance(column_codes, str)
+    assert isinstance(num_rows, int)
+    assert isinstance(random_seed, int)
+    
+    X = _generate_random_sframe(num_rows, column_codes, random_seed, False, 0)
+    X.__materialize__()
+    return X
+
+def generate_random_regression_sframe(num_rows, column_codes, random_seed = 0, target_noise_level = 0.25):
+    """
+    Creates a random SFrame with `num_rows` rows and randomly
+    generated column types determined by `column_codes`.  The output
+    SFrame is deterministic based on `random_seed`.  In addition, a
+    target column is generated with values dependent on the randomly
+    generated features in a given row.
+ 
+     `column_types` is a string with each character denoting one type
+     of column, with the output SFrame having one column for each
+     character in the string.  The legend is as follows:
+
+        n:  numeric column, uniform 0-1 distribution. 
+        N:  numeric column, uniform 0-1 distribution, 1% NaNs.
+        r:  numeric column, uniform -100 to 100 distribution. 
+        R:  numeric column, uniform -10000 to 10000 distribution, 1% NaNs.
+        b:  binary integer column, uniform distribution
+        z:  integer column with random integers between 1 and 10.
+        Z:  integer column with random integers between 1 and 100.
+        s:  categorical string column with 10 different unique short strings. 
+        S:  categorical string column with 100 different unique short strings. 
+        c:  categorical column with short string keys and 1000 unique values, triangle distribution.
+        C:  categorical column with short string keys and 100000 unique values, triangle distribution.
+        x:  categorical column with 128bit hex hashes and 1000 unique values. 
+        X:  categorical column with 256bit hex hashes and 100000 unique values. 
+        h:  column with unique 128bit hex hashes.
+        H:  column with unique 256bit hex hashes.
+
+        l:  categorical list with between 0 and 10 unique integer elements from a pool of 100 unique values. 
+        L:  categorical list with between 0 and 100 unique integer elements from a pool of 1000 unique values.
+        M:  categorical list with between 0 and 10 unique string elements from a pool of 100 unique values. 
+        m:  categorical list with between 0 and 100 unique string elements from a pool of 1000 unique values.
+
+        v:  numeric vector with 10 elements and uniform 0-1 elements.
+        V:  numeric vector with 1000 elements and uniform 0-1 elements.
+        w:  numeric vector with 10 elements and uniform 0-1 elements, 1% NANs.
+        W:  numeric vector with 1000 elements and uniform 0-1 elements, 1% NANs.
+
+        d: dictionary with with between 0 and 10 string keys from a
+           pool of 100 unique keys, and random 0-1 values.
+
+        D: dictionary with with between 0 and 100 string keys from a
+           pool of 1000 unique keys, and random 0-1 values.
+
+    For example::
+
+      X = generate_random_sframe(10, 'nnv')
+
+    will generate a 10 row SFrame with 2 floating point columns and
+    one column of length 10 vectors.
+    
+    Target Generation
+    -----------------
+
+    the target value is a linear
+    combination of the features chosen for each row plus uniform noise.
+    
+    - For each numeric and vector columns, each value, with the range
+      scaled to [-0.5, 0.5] (so r and R type values affect the target just
+      as much as n an N), is added to the target value.  NaNs are ignored.
+    
+    - For each categorical or string values, it is hash-mapped to a lookup
+      table of 512 randomly chosen values, each in [-0.5, 0.5], and the
+      result is added to the target.
+    
+    - For dictionary columns, the keys are treated as adding a categorical
+      value and the values are treated as adding a numeric value. 
+    
+    At the end, a uniform random value is added to the target in the
+    range [(max_target - min_target) * noise_level], where max_target
+    and min_target are the maximum and minimum target values generated
+    by the above process.
+   
+    The final target values are then scaled to [0, 1].
+    """
+
+    from ..extensions import _generate_random_sframe
+
+    assert isinstance(column_codes, str)
+    assert isinstance(num_rows, int)
+    assert isinstance(random_seed, int)
+        
+    X = _generate_random_sframe(num_rows, column_codes, random_seed, True, target_noise_level)
+    X.__materialize__()
+    return X
+    
+def generate_random_classification_sframe(num_rows, column_codes, num_classes,
+                                          misclassification_spread = 0.25,
+                                          num_extra_class_bins = None,
+                                          random_seed = 0):
+    """
+    Creates a random SFrame with `num_rows` rows and randomly
+    generated column types determined by `column_codes`.  The output
+    SFrame is deterministic based on `random_seed`.  In addition, a
+    target column is generated with values dependent on the randomly
+    generated features in a given row.
+ 
+     `column_types` is a string with each character denoting one type
+     of column, with the output SFrame having one column for each
+     character in the string.  The legend is as follows:
+
+        n:  numeric column, uniform 0-1 distribution. 
+        N:  numeric column, uniform 0-1 distribution, 1% NaNs.
+        r:  numeric column, uniform -100 to 100 distribution. 
+        R:  numeric column, uniform -10000 to 10000 distribution, 1% NaNs.
+        b:  binary integer column, uniform distribution
+        z:  integer column with random integers between 1 and 10.
+        Z:  integer column with random integers between 1 and 100.
+        s:  categorical string column with 10 different unique short strings. 
+        S:  categorical string column with 100 different unique short strings. 
+        c:  categorical column with short string keys and 1000 unique values, triangle distribution.
+        C:  categorical column with short string keys and 100000 unique values, triangle distribution.
+        x:  categorical column with 128bit hex hashes and 1000 unique values. 
+        X:  categorical column with 256bit hex hashes and 100000 unique values. 
+        h:  column with unique 128bit hex hashes.
+        H:  column with unique 256bit hex hashes.
+
+        l:  categorical list with between 0 and 10 unique integer elements from a pool of 100 unique values. 
+        L:  categorical list with between 0 and 100 unique integer elements from a pool of 1000 unique values.
+        M:  categorical list with between 0 and 10 unique string elements from a pool of 100 unique values. 
+        m:  categorical list with between 0 and 100 unique string elements from a pool of 1000 unique values.
+
+        v:  numeric vector with 10 elements and uniform 0-1 elements.
+        V:  numeric vector with 1000 elements and uniform 0-1 elements.
+        w:  numeric vector with 10 elements and uniform 0-1 elements, 1% NANs.
+        W:  numeric vector with 1000 elements and uniform 0-1 elements, 1% NANs.
+
+        d: dictionary with with between 0 and 10 string keys from a
+           pool of 100 unique keys, and random 0-1 values.
+
+        D: dictionary with with between 0 and 100 string keys from a
+           pool of 1000 unique keys, and random 0-1 values.
+
+    For example::
+
+      X = generate_random_sframe(10, 'nnv')
+
+    will generate a 10 row SFrame with 2 floating point columns and
+    one column of length 10 vectors.
+    
+    Target Generation
+    -----------------
+
+    The target column, called "target", is an integer value that
+    represents the binning of the output of a noisy linear function of
+    the chosen random variables into `num_classes + num_extra_class_bins`
+    bins, shuffled, and then each bin is mapped to a class.  This
+    means that some non-linearity is present if num_extra_class_bins > 0.
+    The default value for num_extra_class_bins is 2*num_classes.
+
+    The `misclassification_probability` controls the spread of the
+    binning -- if misclassification_spread equals 0.25, then a random
+    variable of 0.25 * bin_width is added to the numeric prediction of
+    the class, meaning the actual class may be mispredicted.
+    """
+
+    from ..extensions import _generate_random_classification_sframe
+            
+    if num_classes < 2:
+        raise ValueError("num_classes must be >= 2.")
+
+    if num_extra_class_bins is None:
+        num_extra_class_bins = 2*num_classes
+
+    if num_extra_class_bins < 0:
+        raise ValueError("num_extra_class_bins must be >= 0.")
+
+    if misclassification_spread < 0:
+        raise ValueError("misclassification_spread must be >= 0.")
+    
+    assert isinstance(column_codes, str)
+    assert isinstance(num_rows, int)
+    assert isinstance(random_seed, int)
+    assert isinstance(num_classes, int)
+    assert isinstance(num_extra_class_bins, int)
+
+            
+    X = _generate_random_classification_sframe(
+        num_rows, column_codes, random_seed,
+        num_classes, num_extra_class_bins, misclassification_spread)
+    
+    X.__materialize__()
+    return X
+    


### PR DESCRIPTION
This pull request adds in generation utilities to create random
SFrames of many different types for testing and benchmarking.  The
generation is done efficiently in C++.  The routines existed prior to
this in C++, but this pull request tweaks the API based on practical
use cases, plus exposes them to python.

The new functions are:

util.generate_random_sframe
util.generate_random_regression_sframe
util.generate_random_classification_sframe

To use, specify the number of rows and the codes for the columns.  The
codes are outlined in detail in the documentation for the above
functions, and are:

        n:  numeric column, uniform 0-1 distribution.
        N:  numeric column, uniform 0-1 distribution, 1% NaNs.
        r:  numeric column, uniform -100 to 100 distribution.
        R:  numeric column, uniform -10000 to 10000 distribution, 1% NaNs.
        b:  binary integer column, uniform distribution
        z:  integer column with random integers between 1 and 10.
        Z:  integer column with random integers between 1 and 100.
        s:  categorical string column with 10 different unique short strings.
        S:  categorical string column with 100 different unique short strings.
        c:  categorical column with short string keys and 1000 unique values, triangle distribution.
        C:  categorical column with short string keys and 100000 unique values, triangle distribution.
        x:  categorical column with 128bit hex hashes and 1000 unique values.
        X:  categorical column with 256bit hex hashes and 100000 unique values.
        h:  column with unique 128bit hex hashes.
        H:  column with unique 256bit hex hashes.

        l:  categorical list with between 0 and 10 unique integer elements from a pool of 100 unique values.
        L:  categorical list with between 0 and 100 unique integer elements from a pool of 1000 unique values.
        M:  categorical list with between 0 and 10 unique string elements from a pool of 100 unique values.
        m:  categorical list with between 0 and 100 unique string elements from a pool of 1000 unique values.

        v:  numeric vector with 10 elements and uniform 0-1 elements.
        V:  numeric vector with 1000 elements and uniform 0-1 elements.
        w:  numeric vector with 10 elements and uniform 0-1 elements, 1% NANs.
        W:  numeric vector with 1000 elements and uniform 0-1 elements, 1% NANs.

        d: dictionary with with between 0 and 10 string keys from a
           pool of 100 unique keys, and random 0-1 values.

        D: dictionary with with between 0 and 100 string keys from a
           pool of 1000 unique keys, and random 0-1 values.

For example::

      X = generate_random_sframe(10, 'nnv')

will generate a 10 row SFrame with 2 floating point columns and one column of length-10 numeric vectors.

Additionally, util.generate_random_regression_sframe and
util.generate_random_classification_sframe generate a target column,
with the target being a noisy linear function of the generated
features in each row.

The above have proven useful for C++ testing.