### PR TITLE
Fix log progress printing and ctrl-c

### DIFF
--- a/oss_src/cppipc/client/comm_client.cpp
+++ b/oss_src/cppipc/client/comm_client.cpp
@@ -70,7 +70,8 @@ comm_client::comm_client(std::string name, void* zmq_ctx) :
                boost::bind(&comm_client::subscribe_callback, this, _1)),
     endpoint_name(name) {
       ASSERT_MSG(boost::starts_with(name, "inproc://"), "This constructor only supports inproc address");
-      init();
+      bool ops_interruptible = true;
+      init(ops_interruptible);
 }
 
 void comm_client::init(bool ops_interruptible) {

--- a/oss_src/unity/python/sframe/connect/server.py
+++ b/oss_src/unity/python/sframe/connect/server.py
@@ -39,6 +39,10 @@ class GraphLabServer(object):
         """ Stops the server. """
         raise NotImplementedError
 
+    def set_log_progress(self, enable):
+        """ Enable or disable log progress printing """
+        raise NotImplementedError
+
     def try_stop(self):
         """ Try stopping the server and swallow the exception. """
         try:
@@ -118,6 +122,9 @@ class EmbeddedServer(GraphLabServer):
     def get_logger(self):
         return self.logger
 
+    def set_log_progress(self, enable):
+        self.dll.set_log_progress(enable)
+
     def _load_dll_ok(self, root_path):
         server_env = _sys_util.make_unity_server_env()
         os.environ.update(server_env)
@@ -137,6 +144,7 @@ class EmbeddedServer(GraphLabServer):
         try:
             self.dll.start_server.argtypes = [c_char_p, c_char_p, c_char_p, c_ulonglong, c_ulonglong]
             self.dll.get_client.restype = c_void_p
+            self.dll.set_log_progress.argtypes = [c_bool]
             self.dll.stop_server
         except Exception as e:
             return (False, str(e))

--- a/oss_src/unity/python/sframe/cython/cy_ipc.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pxd
@@ -19,25 +19,13 @@ cdef extern from "<cppipc/client/comm_client.hpp>" namespace 'cppipc':
                       string alternate_control_address, string alternate_publish_address, 
                       string public_key, string secret_key, string server_public_key,
                       ops_interruptible) except +
-        void add_auth_method_token(string authtoken) except +
-        void add_status_watch(string prefix, void(*callback)(string)) except +
-        void remove_status_watch(string prefix) except +
-        void set_server_alive_watch_pid(int pid) except +
         reply_status start() except + 
         void stop() except +
 
 cdef extern from "cppipc/common/message_types.hpp" namespace 'cppipc':
     cdef string reply_status_to_string(reply_status)
 
-cdef extern from "<zmq_utils.h>":
-    cdef string zmq_curve_keypair(char*, char*)
-
-cdef void print_status(string status_string) nogil
-
 cdef class PyCommClient:
     cdef comm_client *thisptr 
-    cpdef add_auth_method_token(self, string authtoken)
-    cpdef set_log_progress(self, bint is_on)
-    cpdef set_server_alive_watch_pid(self, int pid)
     cpdef stop(self)
     cpdef start(self)

--- a/oss_src/unity/python/sframe/cython/cy_ipc.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pxd
@@ -15,10 +15,6 @@ cdef extern from "<cppipc/common/message_types.hpp>" namespace 'cppipc':
 
 cdef extern from "<cppipc/client/comm_client.hpp>" namespace 'cppipc':
     cdef cppclass comm_client nogil:
-        comm_client(vector[string] zkhosts, string name, unsigned int max_init_ping_failures,
-                      string alternate_control_address, string alternate_publish_address, 
-                      string public_key, string secret_key, string server_public_key,
-                      ops_interruptible) except +
         reply_status start() except + 
         void stop() except +
 

--- a/oss_src/unity/python/sframe/cython/cy_ipc.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pyx
@@ -10,12 +10,6 @@ from libcpp.string cimport string
 from libc.stdio cimport printf
 from .python_printer_callback import print_callback
 
-cdef void print_status(string status_string) nogil:
-    with gil:
-        status_string = status_string.rstrip()
-        print_callback(status_string)
-
-
 
 cdef class PyCommClient:
 
@@ -24,21 +18,6 @@ cdef class PyCommClient:
 
     def __dealloc__(self):
         pass
-
-    cpdef set_server_alive_watch_pid(self, int pid):
-        assert self.thisptr != NULL
-        self.thisptr.set_server_alive_watch_pid(pid)
-
-    cpdef set_log_progress(self, bint is_on):
-        assert self.thisptr != NULL
-        if (is_on):
-            self.thisptr.add_status_watch("PROGRESS", print_status)
-        else:
-            self.thisptr.remove_status_watch("PROGRESS")
-
-    cpdef add_auth_method_token(self, string authtoken):
-        assert self.thisptr != NULL
-        self.thisptr.add_auth_method_token(authtoken)
 
     cpdef stop(self):
         assert self.thisptr != NULL
@@ -49,13 +28,6 @@ cdef class PyCommClient:
         cdef reply_status r = self.thisptr.start()
         if (<size_t>r != 0):
             raise RuntimeError(reply_status_to_string(r))
-
-def get_public_secret_key_pair():
-    cdef char public_key[41]
-    cdef char seceret_key[41]
-    zmq_curve_keypair(public_key, seceret_key)
-    return (str(public_key), str(seceret_key))
-
 
 def make_comm_client(string name,
                      unsigned int max_init_ping_failures=3,
@@ -69,11 +41,9 @@ def make_comm_client(string name,
     assert (client_ptr!= NULL), "Fail to create comm client with zkhosts: %s, and host %s" % (str(dummy_zkhosts, name))
     ret = PyCommClient()
     ret.thisptr = client_ptr
-    ret.set_log_progress(True)
     return ret
 
 def make_comm_client_from_existing_ptr(size_t client_ptr):
     ret = PyCommClient()
     ret.thisptr = <comm_client*>(client_ptr)
-    ret.set_log_progress(True)
     return ret

--- a/oss_src/unity/python/sframe/cython/cy_ipc.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pyx
@@ -29,20 +29,6 @@ cdef class PyCommClient:
         if (<size_t>r != 0):
             raise RuntimeError(reply_status_to_string(r))
 
-def make_comm_client(string name,
-                     unsigned int max_init_ping_failures=3,
-                     public_key="",
-                     secret_key="",
-                     server_public_key="",
-                     ops_interruptible=True):
-    cdef vector[string] dummy_zkhosts 
-    client_ptr = new comm_client(dummy_zkhosts, name, max_init_ping_failures, "", "", public_key,
-                                 secret_key, server_public_key, ops_interruptible)
-    assert (client_ptr!= NULL), "Fail to create comm client with zkhosts: %s, and host %s" % (str(dummy_zkhosts, name))
-    ret = PyCommClient()
-    ret.thisptr = client_ptr
-    return ret
-
 def make_comm_client_from_existing_ptr(size_t client_ptr):
     ret = PyCommClient()
     ret.thisptr = <comm_client*>(client_ptr)

--- a/oss_src/unity/python/sframe/data_structures/sframe.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe.py
@@ -1094,7 +1094,7 @@ class SFrame(object):
         _mt._get_metric_tracker().track(('sframe.location.%s' % (suffix)), value=1)
         try:
             if (not verbose):
-                glconnect.get_client().set_log_progress(False)
+                glconnect.get_server().set_log_progress(False)
             with cython_context():
                 errors = proxy.load_from_csvs(internal_url, parsing_config, type_hints)
         except Exception as e:
@@ -1110,13 +1110,13 @@ class SFrame(object):
                     with cython_context():
                         errors = proxy.load_from_csvs(internal_url, parsing_config, type_hints)
                 except:
-                    glconnect.get_client().set_log_progress(True)
+                    glconnect.get_server().set_log_progress(True)
                     raise
             else:
-                glconnect.get_client().set_log_progress(True)
+                glconnect.get_server().set_log_progress(True)
                 raise
 
-        glconnect.get_client().set_log_progress(True)
+        glconnect.get_server().set_log_progress(True)
 
         return (cls(_proxy=proxy), { f: SArray(_proxy = es) for (f, es) in errors.iteritems() })
 
@@ -2035,12 +2035,12 @@ class SFrame(object):
         >>> sf.to_odbc(db, 'a_cool_table')
         """
         if (not verbose):
-            glconnect.get_client().set_log_progress(False)
+            glconnect.get_server().set_log_progress(False)
 
         db._insert_sframe(self, table_name, append_if_exists)
 
         if (not verbose):
-            glconnect.get_client().set_log_progress(True)
+            glconnect.get_server().set_log_progress(True)
 
     def __repr__(self):
         """

--- a/oss_src/unity/python/sframe/toolkits/_main.py
+++ b/oss_src/unity/python/sframe/toolkits/_main.py
@@ -53,7 +53,7 @@ def run(toolkit_name, options, verbose=True, show_progress=False):
     """
     unity = glconnect.get_unity()
     if (not verbose):
-        glconnect.get_client().set_log_progress(False)
+        glconnect.get_server().set_log_progress(False)
     # spawn progress threads
     try:
         start_time = time.time()
@@ -78,7 +78,7 @@ def run(toolkit_name, options, verbose=True, show_progress=False):
     _get_metric_tracker().track(metric_name, value=1, properties=track_props, send_sys_info=False)
 
     # set the verbose level back to default
-    glconnect.get_client().set_log_progress(True)
+    glconnect.get_server().set_log_progress(True)
 
     if success:
         return params

--- a/oss_src/unity/server/unity_server.cpp
+++ b/oss_src/unity/server/unity_server.cpp
@@ -59,12 +59,8 @@ void unity_server::start(const unity_server_initializer& server_initializer) {
                                    options.control_address,
                                    options.publish_address,
                                    options.secret_key);
-  // set the progress observer
-  global_logger().add_observer(
-      LOG_PROGRESS,
-      [=](int lineloglevel, const char* buf, size_t len){
-        server->report_status("progress", std::string(buf, len));
-      });
+
+  set_log_progress(true);
 
   // initialize built-in data structures, toolkits and models, defined in unity_server_init.cpp
   server_initializer.init_toolkits(*toolkit_functions);
@@ -91,20 +87,8 @@ void unity_server::start(const unity_server_initializer& server_initializer) {
 void unity_server::stop() {
   delete server;
   server = nullptr;
-  global_logger().add_observer(LOG_PROGRESS, NULL);
+  set_log_progress(false);
   graphlab::global_teardown::get_instance().perform_teardown();
-}
-
-/**
- * Include the authentication method if the auth token is provided
- */
-void unity_server::set_auth_token() {
-  if (!options.auth_token.empty()) {
-    logstream(LOG_EMPH) << "authentication method: authentication_token applied" << std::endl;
-    server->add_auth_method(std::make_shared<cppipc::authentication_token_method>(options.auth_token));
-  } else {
-    logstream(LOG_EMPH) << "no authentication method." << std::endl;
-  }
 }
 
 /**
@@ -145,5 +129,18 @@ std::string unity_server::parse_server_address(std::string server_address) {
   }
   return server_address;
 }
+
+void unity_server::set_log_progress(bool enable) {
+  global_logger().add_observer(LOG_PROGRESS, NULL);
+  if (enable == true) {
+    // set the progress observer
+    global_logger().add_observer(
+        LOG_PROGRESS,
+        [=](int lineloglevel, const char* buf, size_t len){
+          std::cout << "PROGRESS: " << std::string(buf, len);
+        });
+  }
+}
+
 
 } // end of graphlab

--- a/oss_src/unity/server/unity_server.hpp
+++ b/oss_src/unity/server/unity_server.hpp
@@ -37,16 +37,16 @@ class unity_server {
    */
   void stop();
 
+  /**
+   * Enable or disable log progress stream.
+   */
+  static void set_log_progress(bool enable);
+
   inline cppipc::comm_server* get_comm_server() { return server; }
 
   inline std::string get_comm_server_address() { return options.server_address; }
 
  protected:
-  /**
-   * Include the authentication method if the auth token is provided
-   */
-  void set_auth_token();
-
   /**
    * Parse the server_address and return the parsed address.
    *

--- a/oss_src/unity/server/unity_server_capi.cpp
+++ b/oss_src/unity/server/unity_server_capi.cpp
@@ -26,7 +26,7 @@ void start_server(const unity_server_options& server_options) {
 
   auto zmq_ctx = SERVER->get_comm_server()->get_zmq_context();
   // we are going to leak this pointer 
-  CLIENT = new cppipc::comm_client(SERVER->get_comm_server_address(), zmq_ctx);
+  CLIENT = new cppipc::comm_client(SERVER->get_comm_server_address(),zmq_ctx);
   CLIENT->start();
 }
 

--- a/oss_src/unity/server/unity_server_capi.cpp
+++ b/oss_src/unity/server/unity_server_capi.cpp
@@ -94,4 +94,12 @@ EXPORT void* get_client() {
 EXPORT void stop_server() {
   graphlab::stop_server();
 }
-} // end of extern "C"
+
+/**
+ * Enable or disable log progress stream.
+ */
+EXPORT void set_log_progress(bool enable) {
+  graphlab::unity_server::set_log_progress(enable);
+}
+}
+ // end of extern "C"


### PR DESCRIPTION
Fix two issues: 1. log progress wasn't showing at console and 2. server side operations cannot be interrupted.

The new log progress printing does not go through cppipc anymore.
The first change is to make the logger's progress callback directly print to stdout.
The second change is to expose CAPI which the python client can use to directly switch on/off the global logger's callback.

For the ctrl-c issue, the call to comm_client::init() wasn't using the correct flag for ops_interruptable.
This fixes it.

Also purge unused cython functions of cppipc layer