### PR TITLE
Add DBAPI2 support for SFrame.

### DIFF
--- a/oss_src/flexible_type/flexible_type_base_types.hpp
+++ b/oss_src/flexible_type/flexible_type_base_types.hpp
@@ -768,6 +768,27 @@ struct has_direct_conversion_to_flexible_type {
       flex_type_enum::UNDEFINED;
 };
 
+/**
+ * Given a set of types, choose a common type that all types in the set can be
+ * converted to and preserves the most data. Not designed to be passed a set
+ * with UNDEFINED in it.
+ */
+inline flex_type_enum get_common_type(const std::set<flex_type_enum> &types) {
+  if (types.size() == 0) return flex_type_enum::FLOAT;
+  else if (types.size() == 1) return *(types.begin());
+  else if (types.size() == 2) {
+    if (types.count(flex_type_enum::INTEGER) && types.count(flex_type_enum::FLOAT)) {
+      return flex_type_enum::FLOAT;
+    }
+    if (types.count(flex_type_enum::LIST) && types.count(flex_type_enum::VECTOR)) {
+      return flex_type_enum::LIST;
+    }
+  } else {
+    throw std::string("Could not find a common type to convert all values.");
+  }
+
+  return flex_type_enum::UNDEFINED;
+}
 
 } // namespace graphlab
 

--- a/oss_src/unity/extensions/sarray_builder.cpp
+++ b/oss_src/unity/extensions/sarray_builder.cpp
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#include <unity/lib/unity_sarray_builder.hpp>
+
+namespace graphlab {
+
+//TODO: Add a hint for the size?
+void unity_sarray_builder::init(size_t num_segments, size_t history_size, flex_type_enum dtype) {
+  if(m_inited)
+    log_and_throw("This sarray_builder has already been initialized!");
+
+
+  m_sarray.open_for_write(num_segments);
+  m_out_iters.resize(num_segments);
+  for(size_t i = 0; i < num_segments; ++i) {
+    m_out_iters[i] = m_sarray.get_output_iterator(i);
+  }
+  m_history = std::make_shared<boost::circular_buffer<flexible_type>>(history_size);
+  m_given_dtype = dtype;
+  if(dtype != flex_type_enum::UNDEFINED)
+    m_ary_type = m_given_dtype;
+
+  m_inited = true;
+}
+
+//TODO: Should I provide instant feedback when an inserted type will cause an error?
+void unity_sarray_builder::append(const flexible_type &val, size_t segment) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Cannot append values when closed.");
+
+  if(segment >= m_out_iters.size()) {
+    log_and_throw("Invalid segment number!");
+  }
+
+  m_history->push_back(val);
+  auto in_type = val.get_type();
+  // Only care about types if a dtype was not provided
+  if(m_given_dtype == flex_type_enum::UNDEFINED &&
+      in_type != flex_type_enum::UNDEFINED) {
+    auto ins_ret = m_types_inserted.insert(in_type);
+    if(ins_ret.second) {
+      try {
+        m_ary_type = get_common_type(m_types_inserted);
+      } catch(std::string &e) {
+        m_types_inserted.erase(ins_ret.first);
+        log_and_throw(std::string("Append failed: ") +
+            flex_type_enum_to_name(in_type) + std::string(" type is "
+              "incompatible with types of existing values in this SArray."));
+      }
+    }
+  }
+
+  *(m_out_iters[segment]) = val;
+}
+
+void unity_sarray_builder::append_multiple(const std::vector<flexible_type> &vals, size_t segment) {
+  for(const auto &i : vals) {
+    this->append(i, segment);
+  }
+}
+
+flex_type_enum unity_sarray_builder::get_type() {
+  return m_ary_type;
+}
+
+std::vector<flexible_type> unity_sarray_builder::read_history(size_t num_elems) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("History is invalid when closed.");
+
+  if(num_elems > m_history->size())
+    num_elems = m_history->size();
+
+  if(num_elems == size_t(-1))
+    num_elems = m_history->size();
+
+  std::vector<flexible_type> ret_vec(num_elems);
+  auto riter = m_history->rbegin();
+  size_t ret_vec_idx = num_elems-1;
+  for(; (riter != m_history->rend()); ++riter, --ret_vec_idx) {
+    ret_vec[ret_vec_idx] = *riter;
+  }
+
+  return ret_vec;
+}
+
+std::shared_ptr<unity_sarray_base> unity_sarray_builder::close() {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Already closed.");
+
+  // This will fail if the user supplied types go against the dtype they provided
+  m_sarray.set_type(m_ary_type);
+
+  m_sarray.close();
+  m_closed = true;
+  auto ret = std::make_shared<unity_sarray>();
+  ret->construct_from_sarray(m_sarray);
+  return ret;
+}
+
+} // namespace graphlab

--- a/oss_src/unity/extensions/sarray_builder.hpp
+++ b/oss_src/unity/extensions/sarray_builder.hpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef GRAPHLAB_UNITY_SARRAY_BUILDER_HPP
+#define GRAPHLAB_UNITY_SARRAY_BUILDER_HPP
+
+#include <vector>
+#include <sframe/sarray.hpp>
+#include <boost/circular_buffer.hpp>
+#include <unity/lib/api/unity_sarray_builder_interface.hpp>
+
+namespace graphlab {
+
+// forward declarations
+template <typename T>
+class sarray;
+
+class unity_sarray_builder: public unity_sarray_builder_base {
+ public:
+  void init(size_t num_segments, size_t history_size, flex_type_enum dtype);
+
+  void append(const flexible_type &val, size_t segment);
+  void append_multiple(const std::vector<flexible_type> &vals, size_t segment);
+
+  flex_type_enum get_type();
+  std::vector<flexible_type> read_history(size_t num_elems=size_t(-1));
+  std::shared_ptr<unity_sarray_base> close();
+ private:
+  /// Methods
+
+  /// Variables
+  bool m_inited = false;
+  bool m_closed = false;
+  sarray<flexible_type> m_sarray;
+  std::vector<sarray<flexible_type>::iterator> m_out_iters;
+  flex_type_enum m_ary_type = flex_type_enum::UNDEFINED;
+  flex_type_enum m_given_dtype = flex_type_enum::UNDEFINED;
+  std::set<flex_type_enum> m_types_inserted;
+
+  std::shared_ptr<boost::circular_buffer<flexible_type>> m_history;
+};
+
+} // namespace graphlab
+#endif // GRAPHLAB_UNITY_SARRAY_BUILDER_HPP

--- a/oss_src/unity/lib/CMakeLists.txt
+++ b/oss_src/unity/lib/CMakeLists.txt
@@ -28,6 +28,8 @@ make_library(unity_core
     image_util.cpp
     ../extensions/additional_sframe_utilities.cpp
     ../extensions/cumulative_aggregates.cpp
+    unity_sarray_builder.cpp
+    unity_sframe_builder.cpp
   REQUIRES
     flexible_type
     pylambda table_printer

--- a/oss_src/unity/lib/api/unity_sarray_builder_interface.hpp
+++ b/oss_src/unity/lib/api/unity_sarray_builder_interface.hpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef GRAPHLAB_UNITY_SARRAY_BUILDER_INTERFACE_HPP
+#define GRAPHLAB_UNITY_SARRAY_BUILDER_INTERFACE_HPP
+#include <vector>
+#include <flexible_type/flexible_type.hpp>
+#include <cppipc/magic_macros.hpp>
+
+namespace graphlab {
+
+class unity_sarray_base;
+
+GENERATE_INTERFACE_AND_PROXY(unity_sarray_builder_base, unity_sarray_builder_proxy,
+      (void, init, (size_t)(size_t)(flex_type_enum))
+      (void, append, (const flexible_type&)(size_t))
+      (void, append_multiple, (const std::vector<flexible_type>&)(size_t))
+      (flex_type_enum, get_type, )
+      (std::vector<flexible_type>, read_history, (size_t))
+      (std::shared_ptr<unity_sarray_base>, close, )
+    )
+
+} // namespace graphlab
+
+#endif //GRAPHLAB_UNITY_SARRAY_BUILDER_INTERFACE_HPP
+#include <unity/lib/api/unity_sarray_interface.hpp>

--- a/oss_src/unity/lib/api/unity_sframe_builder_interface.hpp
+++ b/oss_src/unity/lib/api/unity_sframe_builder_interface.hpp
@@ -1,0 +1,25 @@
+#ifndef GRAPHLAB_UNITY_SFRAME_BUILDER_INTERFACE_HPP
+#define GRAPHLAB_UNITY_SFRAME_BUILDER_INTERFACE_HPP
+#include <vector>
+#include <string>
+#include <flexible_type/flexible_type.hpp>
+#include <cppipc/magic_macros.hpp>
+
+namespace graphlab {
+
+class unity_sframe_base;
+
+GENERATE_INTERFACE_AND_PROXY(unity_sframe_builder_base, unity_sframe_builder_proxy,
+      (void, init, (size_t)(size_t)(std::vector<std::string>)(std::vector<flex_type_enum>))
+      (void, append, (const std::vector<flexible_type>&)(size_t))
+      (void, append_multiple, (const std::vector<std::vector<flexible_type>>&)(size_t))
+      (std::vector<std::string>, column_names, )
+      (std::vector<flex_type_enum>, column_types, )
+      (std::vector<std::vector<flexible_type>>, read_history, (size_t))
+      (std::shared_ptr<unity_sframe_base>, close, )
+    )
+
+} // namespace graphlab
+
+#endif //GRAPHLAB_UNITY_SFRAME_BUILDER_INTERFACE_HPP
+#include <unity/lib/api/unity_sframe_interface.hpp>

--- a/oss_src/unity/lib/gl_sarray.cpp
+++ b/oss_src/unity/lib/gl_sarray.cpp
@@ -40,17 +40,12 @@ flex_type_enum infer_type_of_list(const std::vector<flexible_type>& vec) {
       last_type = val.get_type();
     }
   }
-  if (types.size() == 0) return flex_type_enum::FLOAT;
-  else if (types.size() == 1) return *(types.begin());
-  else if (types.size() == 2) {
-    if (types.count(flex_type_enum::INTEGER) && types.count(flex_type_enum::FLOAT)) {
-      return flex_type_enum::FLOAT;
-    }
-    if (types.count(flex_type_enum::LIST) && types.count(flex_type_enum::VECTOR)) {
-      return flex_type_enum::LIST;
-    }
+
+  try {
+    return get_common_type(types);
+  } catch(std::string &e) {
+    throw std::string("Cannot infer Array type. Not all elements of array are the same type.");
   }
-  throw std::string("Cannot infer Array type. Not all elements of array are the same type.");
 }
 
 /**************************************************************************/

--- a/oss_src/unity/lib/unity_sarray_builder.cpp
+++ b/oss_src/unity/lib/unity_sarray_builder.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#include <unity/lib/unity_sarray_builder.hpp>
+#include <unity/lib/unity_sarray.hpp>
+
+namespace graphlab {
+
+void unity_sarray_builder::init(size_t num_segments, size_t history_size, flex_type_enum dtype) {
+  if(m_inited)
+    log_and_throw("This sarray_builder has already been initialized!");
+
+  m_sarray = std::make_shared<sarray<flexible_type>>();
+  m_sarray->open_for_write(num_segments);
+  m_out_iters.resize(num_segments);
+  for(size_t i = 0; i < num_segments; ++i) {
+    m_out_iters[i] = m_sarray->get_output_iterator(i);
+  }
+  m_history = std::make_shared<boost::circular_buffer<flexible_type>>(history_size);
+  m_given_dtype = dtype;
+  if(dtype != flex_type_enum::UNDEFINED)
+    m_ary_type = m_given_dtype;
+
+  m_inited = true;
+}
+
+void unity_sarray_builder::append(const flexible_type &val, size_t segment) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Cannot append values when closed.");
+
+  if(segment >= m_out_iters.size()) {
+    log_and_throw("Invalid segment number!");
+  }
+
+  m_history->push_back(val);
+  auto in_type = val.get_type();
+  // Only care about types if a dtype was not provided
+  if(m_given_dtype == flex_type_enum::UNDEFINED &&
+      in_type != flex_type_enum::UNDEFINED) {
+    auto ins_ret = m_types_inserted.insert(in_type);
+    if(ins_ret.second) {
+      // Not allowed to change types in the middle of appending (except from
+      // UNDEFINED)
+      if(m_types_inserted.size() > 1) {
+        m_types_inserted.erase(ins_ret.first);
+        log_and_throw(std::string("Append failed: ") +
+            flex_type_enum_to_name(in_type) + std::string(" type is "
+              "incompatible with types of existing values in this SArray."));
+      }
+      m_ary_type = in_type;
+    }
+  }
+
+  *(m_out_iters[segment]) = val;
+}
+
+void unity_sarray_builder::append_multiple(const std::vector<flexible_type> &vals, size_t segment) {
+  for(const auto &i : vals) {
+    this->append(i, segment);
+  }
+}
+
+flex_type_enum unity_sarray_builder::get_type() {
+  return m_ary_type;
+}
+
+std::vector<flexible_type> unity_sarray_builder::read_history(size_t num_elems) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("History is invalid when closed.");
+
+  if(num_elems > m_history->size())
+    num_elems = m_history->size();
+  if(num_elems == size_t(-1))
+    num_elems = m_history->size();
+
+  std::vector<flexible_type> ret_vec(num_elems);
+
+  if(num_elems == 0)
+    return ret_vec;
+
+  auto riter = m_history->rbegin();
+  ssize_t ret_vec_idx = num_elems-1;
+  for(; ((riter != m_history->rend()) && ret_vec_idx >= 0); ++riter, --ret_vec_idx) {
+    ret_vec[ret_vec_idx] = *riter;
+  }
+
+  return ret_vec;
+}
+
+std::shared_ptr<unity_sarray_base> unity_sarray_builder::close() {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Already closed.");
+
+  // This will fail if the user supplied types go against the dtype they provided
+  m_sarray->set_type(m_ary_type);
+
+  m_sarray->close();
+  m_closed = true;
+  auto ret = std::make_shared<unity_sarray>();
+  ret->construct_from_sarray(m_sarray);
+  return ret;
+}
+
+} // namespace graphlab

--- a/oss_src/unity/lib/unity_sarray_builder.hpp
+++ b/oss_src/unity/lib/unity_sarray_builder.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef GRAPHLAB_UNITY_SARRAY_BUILDER_HPP
+#define GRAPHLAB_UNITY_SARRAY_BUILDER_HPP
+
+#include <vector>
+#include <sframe/sarray.hpp>
+#include <boost/circular_buffer.hpp>
+#include <unity/lib/api/unity_sarray_builder_interface.hpp>
+
+namespace graphlab {
+
+// forward declarations
+template <typename T>
+class sarray;
+
+class unity_sarray_builder: public unity_sarray_builder_base {
+ public:
+  void init(size_t num_segments, size_t history_size, flex_type_enum dtype);
+
+  void append(const flexible_type &val, size_t segment);
+  void append_multiple(const std::vector<flexible_type> &vals, size_t segment);
+
+  flex_type_enum get_type();
+
+  /**
+   * Return the last `num_elems` elements appended.
+   */
+  std::vector<flexible_type> read_history(size_t num_elems);
+  std::shared_ptr<unity_sarray_base> close();
+ private:
+  /// Methods
+
+  /// Variables
+  bool m_inited = false;
+  bool m_closed = false;
+  std::shared_ptr<sarray<flexible_type>> m_sarray;
+  std::vector<sarray<flexible_type>::iterator> m_out_iters;
+  flex_type_enum m_ary_type = flex_type_enum::UNDEFINED;
+  flex_type_enum m_given_dtype = flex_type_enum::UNDEFINED;
+  std::set<flex_type_enum> m_types_inserted;
+
+  std::shared_ptr<boost::circular_buffer<flexible_type>> m_history;
+};
+
+} // namespace graphlab
+#endif // GRAPHLAB_UNITY_SARRAY_BUILDER_HPP

--- a/oss_src/unity/lib/unity_sframe_builder.cpp
+++ b/oss_src/unity/lib/unity_sframe_builder.cpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#include <unity/lib/unity_sframe_builder.hpp>
+#include <unity/lib/unity_sframe.hpp>
+
+namespace graphlab {
+
+void unity_sframe_builder::init(size_t num_segments,
+                                size_t history_size,
+                                std::vector<std::string> column_names,
+                                std::vector<flex_type_enum> column_types) {
+  if(m_inited)
+    log_and_throw("This sframe_builder has already been initialized!");
+
+  //m_sframe = std::make_shared<sframe>();
+  m_sframe.open_for_write(column_names, column_types, "", num_segments);
+  m_out_iters.resize(num_segments);
+  for(size_t i = 0; i < num_segments; ++i) {
+    m_out_iters[i] = m_sframe.get_output_iterator(i);
+  }
+  m_history = std::make_shared<row_history_t>(history_size);
+
+  m_inited = true;
+}
+
+void unity_sframe_builder::append(const std::vector<flexible_type> &row, size_t segment) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Cannot append values when closed.");
+
+  if(segment >= m_out_iters.size()) {
+    log_and_throw("Invalid segment number!");
+  }
+
+  m_history->push_back(row);
+
+  *(m_out_iters[segment]) = row;
+}
+
+void unity_sframe_builder::append_multiple(const std::vector<std::vector<flexible_type>> &vals, size_t segment) {
+  for(const auto &i : vals) {
+    this->append(i, segment);
+  }
+}
+  
+std::vector<std::string> unity_sframe_builder::column_names() {
+  return m_sframe.column_names();
+}
+
+std::vector<flex_type_enum> unity_sframe_builder::column_types() {
+  return m_sframe.column_types();
+}
+
+std::vector<std::vector<flexible_type>> unity_sframe_builder::read_history(size_t num_elems) {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("History is invalid when closed.");
+
+  if(num_elems > m_history->size())
+    num_elems = m_history->size();
+  if(num_elems == size_t(-1))
+    num_elems = m_history->size();
+
+  std::vector<std::vector<flexible_type>> ret_vec(num_elems);
+
+  if(num_elems == 0)
+    return ret_vec;
+
+  auto riter = m_history->rbegin();
+  ssize_t ret_vec_idx = num_elems-1;
+  for(; ((riter != m_history->rend()) && ret_vec_idx >= 0); ++riter, --ret_vec_idx) {
+    ret_vec[ret_vec_idx] = *riter;
+  }
+
+  return ret_vec;
+}
+
+std::shared_ptr<unity_sframe_base> unity_sframe_builder::close() {
+  if(!m_inited)
+    log_and_throw("Must call 'init' first!");
+
+  if(m_closed)
+    log_and_throw("Already closed.");
+
+  m_sframe.close();
+  m_closed = true;
+  auto ret = std::make_shared<unity_sframe>();
+  ret->construct_from_sframe(m_sframe);
+  return ret;
+}
+
+} // namespace graphlab

--- a/oss_src/unity/lib/unity_sframe_builder.hpp
+++ b/oss_src/unity/lib/unity_sframe_builder.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef GRAPHLAB_UNITY_SFRAME_BUILDER_HPP
+#define GRAPHLAB_UNITY_SFRAME_BUILDER_HPP
+
+#include <vector>
+#include <set>
+#include <sframe/sframe.hpp>
+#include <boost/circular_buffer.hpp>
+#include <unity/lib/api/unity_sframe_builder_interface.hpp>
+
+typedef boost::circular_buffer<std::vector<graphlab::flexible_type>> row_history_t;
+
+namespace graphlab {
+
+class unity_sframe_builder: public unity_sframe_builder_base {
+ public:
+  void init(size_t num_segments,
+      size_t history_size,
+      std::vector<std::string> column_names,
+      std::vector<flex_type_enum> column_types);
+
+  void append(const std::vector<flexible_type> &row, size_t segment);
+  void append_multiple(const std::vector<std::vector<flexible_type>> &rows,
+      size_t segment);
+
+  std::vector<std::string> column_names();
+  std::vector<flex_type_enum> column_types();
+  std::vector<std::vector<flexible_type>> read_history(size_t num_elems);
+  std::shared_ptr<unity_sframe_base> close();
+ private:
+  /// Methods
+
+  /// Variables
+  bool m_inited = false;
+  bool m_closed = false;
+  sframe m_sframe;
+  std::vector<sframe::iterator> m_out_iters;
+  flex_type_enum m_ary_type = flex_type_enum::UNDEFINED;
+
+  std::shared_ptr<row_history_t> m_history;
+
+};
+
+} // namespace graphlab
+#endif // GRAPHLAB_UNITY_SFRAME_BUILDER_HPP

--- a/oss_src/unity/python/sframe/__init__.py
+++ b/oss_src/unity/python/sframe/__init__.py
@@ -33,6 +33,8 @@ from .data_structures.sframe import SFrame
 from .data_structures.sarray import SArray
 from .data_structures.sketch import Sketch
 from .data_structures.image import Image
+from .data_structures.sarray_builder import SArrayBuilder
+from .data_structures.sframe_builder import SFrameBuilder
 
 from .data_structures.sgraph import load_sgraph, load_graph
 

--- a/oss_src/unity/python/sframe/cython/cy_sarray_builder.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_sarray_builder.pxd
@@ -1,0 +1,43 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+
+from .cy_ipc cimport comm_client
+from .cy_ipc cimport PyCommClient
+from .cy_flexible_type cimport flex_type_enum
+from .cy_flexible_type cimport flexible_type
+from libcpp.vector cimport vector
+from .cy_unity_base_types cimport *
+
+cdef extern from "<unity/lib/api/unity_sarray_builder_interface.hpp>" namespace 'graphlab':
+    cdef cppclass unity_sarray_builder_proxy nogil:
+        unity_sarray_builder_proxy(comm_client) except +
+        void init(size_t, size_t, flex_type_enum) except +
+        void append(flexible_type, size_t) except +
+        void append_multiple(vector[flexible_type], size_t) except +
+        flex_type_enum get_type() except +
+        vector[flexible_type] read_history(size_t) except +
+        unity_sarray_base_ptr close() except +
+
+cdef create_proxy_wrapper_from_existing_proxy(PyCommClient cli, const unity_sarray_builder_base_ptr& proxy)
+
+cdef class UnitySArrayBuilderProxy:
+    cdef unity_sarray_builder_base_ptr _base_ptr
+    cdef unity_sarray_builder_proxy* thisptr
+    cdef _cli
+
+    cpdef init(self, size_t num_segments, size_t history_size, type dtype) 
+
+    cpdef append(self, val, size_t segment)
+
+    cpdef append_multiple(self, vals, size_t segment)
+
+    cpdef read_history(self, size_t num_elems)
+
+    cpdef get_type(self)
+
+    cpdef close(self)

--- a/oss_src/unity/python/sframe/cython/cy_sarray_builder.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_sarray_builder.pyx
@@ -1,0 +1,77 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+### cython utils ###
+from cython.operator cimport dereference as deref
+
+from .cy_ipc cimport PyCommClient
+from .cy_unity_base_types cimport *
+from .cy_flexible_type cimport flex_list
+
+### flexible_type utils ###
+from .cy_flexible_type cimport flex_type_enum_from_pytype
+from .cy_flexible_type cimport pytype_from_flex_type_enum
+from .cy_flexible_type cimport flexible_type_from_pyobject
+from .cy_flexible_type cimport flex_list_from_iterable
+from .cy_flexible_type cimport pylist_from_flex_list
+
+### sarray ###
+from .cy_sarray cimport create_proxy_wrapper_from_existing_proxy as sarray_proxy
+
+cdef create_proxy_wrapper_from_existing_proxy(PyCommClient cli, const unity_sarray_builder_base_ptr& proxy):
+    if proxy.get() == NULL:
+        return None
+    ret = UnitySArrayBuilderProxy(cli, True)
+    ret._base_ptr = proxy
+    ret.thisptr = <unity_sarray_builder_proxy*>(ret._base_ptr.get())
+    return ret
+
+cdef class UnitySArrayBuilderProxy:
+
+    def __cinit__(self, PyCommClient cli, do_not_allocate=None):
+        assert cli, "CommClient is Null"
+        self._cli = cli
+        if do_not_allocate:
+            self._base_ptr.reset()
+            self.thisptr = NULL
+        else:
+            self.thisptr = new unity_sarray_builder_proxy(deref(cli.thisptr))
+            self._base_ptr.reset(<unity_sarray_builder_base*>(self.thisptr))
+
+    cpdef init(self, size_t num_segments, size_t history_size, type dtype):
+        cdef flex_type_enum tmp_type
+        tmp_type = flex_type_enum_from_pytype(dtype)
+        with nogil:
+            self.thisptr.init(num_segments, history_size, tmp_type)
+
+    cpdef append(self, val, size_t segment):
+        cdef flexible_type c_val = flexible_type_from_pyobject(val)
+        with nogil:
+            self.thisptr.append(c_val, segment)
+
+    cpdef append_multiple(self, object vals, size_t segment):
+        cdef flex_list c_vals = flex_list_from_iterable(vals)
+        with nogil:
+            self.thisptr.append_multiple(c_vals, segment)
+
+    cpdef read_history(self, size_t num_elems):
+        cdef flex_list tmp_history
+        with nogil:
+            tmp_history = self.thisptr.read_history(num_elems)
+        return pylist_from_flex_list(tmp_history)
+
+    cpdef get_type(self):
+        cdef flex_type_enum ret_type
+        with nogil:
+            ret_type = self.thisptr.get_type()
+        return pytype_from_flex_type_enum(ret_type)
+
+    cpdef close(self):
+        cdef unity_sarray_base_ptr proxy
+        with nogil:
+            proxy = self.thisptr.close()
+        return sarray_proxy(self._cli, proxy)

--- a/oss_src/unity/python/sframe/cython/cy_sframe_builder.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_sframe_builder.pxd
@@ -1,0 +1,46 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+from .cy_ipc cimport comm_client
+from .cy_ipc cimport PyCommClient
+from .cy_flexible_type cimport flex_type_enum
+from .cy_flexible_type cimport flexible_type
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from .cy_unity_base_types cimport *
+
+cdef extern from "<unity/lib/api/unity_sframe_builder_interface.hpp>" namespace 'graphlab':
+    cdef cppclass unity_sframe_builder_proxy nogil:
+        unity_sframe_builder_proxy(comm_client) except +
+        void init(size_t, size_t, vector[string], vector[flex_type_enum]) except +
+        void append(const vector[flexible_type]&, size_t) except +
+        void append_multiple(const vector[vector[flexible_type]]&, size_t) except +
+        vector[string] column_names() except +
+        vector[flex_type_enum] column_types() except +
+        vector[vector[flexible_type]] read_history(size_t) except +
+        unity_sframe_base_ptr close() except +
+
+cdef create_proxy_wrapper_from_existing_proxy(PyCommClient cli, const unity_sframe_builder_base_ptr& proxy)
+
+cdef class UnitySFrameBuilderProxy:
+    cdef unity_sframe_builder_base_ptr _base_ptr
+    cdef unity_sframe_builder_proxy* thisptr
+    cdef _cli
+
+    cpdef init(self, object column_types, vector[string] column_names, size_t num_segments, size_t history_size)
+
+    cpdef append(self, row, size_t segment)
+
+    cpdef append_multiple(self, object rows, size_t segment)
+
+    cpdef read_history(self, size_t num_elems)
+
+    cpdef column_names(self)
+
+    cpdef column_types(self)
+
+    cpdef close(self)

--- a/oss_src/unity/python/sframe/cython/cy_sframe_builder.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_sframe_builder.pyx
@@ -1,0 +1,76 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+### cython utils ###
+from cython.operator cimport dereference as deref
+
+from .cy_ipc cimport PyCommClient
+from .cy_unity_base_types cimport *
+from .cy_flexible_type cimport flex_list
+
+### flexible_type utils ###
+from .cy_flexible_type cimport flex_type_enum_from_pytype
+from .cy_flexible_type cimport pytype_from_flex_type_enum
+from .cy_flexible_type cimport flex_list_from_iterable
+from .cy_flexible_type cimport pylist_from_flex_list
+
+### sframe ###
+from .cy_sframe cimport create_proxy_wrapper_from_existing_proxy as sframe_proxy
+
+cdef create_proxy_wrapper_from_existing_proxy(PyCommClient cli, const unity_sframe_builder_base_ptr& proxy):
+    if proxy.get() == NULL:
+        return None
+    ret = UnitySFrameBuilderProxy(cli, True)
+    ret._base_ptr = proxy
+    ret.thisptr = <unity_sframe_builder_proxy*>(ret._base_ptr.get())
+    return ret
+
+cdef class UnitySFrameBuilderProxy:
+
+    def __cinit__(self, PyCommClient cli, do_not_allocate=None):
+        assert cli, "CommClient is Null"
+        self._cli = cli
+        if do_not_allocate:
+            self._base_ptr.reset()
+            self.thisptr = NULL
+        else:
+            self.thisptr = new unity_sframe_builder_proxy(deref(cli.thisptr))
+            self._base_ptr.reset(<unity_sframe_builder_base*>(self.thisptr))
+
+    cpdef init(self, object column_types, vector[string] column_names, size_t num_segments, size_t history_size):
+        cdef vector[flex_type_enum] tmp_column_types
+        for i in column_types:
+          tmp_column_types.push_back(flex_type_enum_from_pytype(i))
+        with nogil:
+            self.thisptr.init(num_segments, history_size, column_names, tmp_column_types)
+
+    cpdef append(self, row, size_t segment):
+        cdef flex_list c_row = flex_list_from_iterable(row)
+        with nogil:
+            self.thisptr.append(c_row, segment)
+
+    cpdef append_multiple(self, object rows, size_t segment):
+        cdef vector[vector[flexible_type]] c_vals 
+        for i in rows:
+            c_vals.push_back(flex_list_from_iterable(i))
+        self.thisptr.append_multiple(c_vals, segment)
+
+    cpdef read_history(self, size_t num_elems):
+        tmp_history = self.thisptr.read_history(num_elems)
+        return [pylist_from_flex_list(i) for i in tmp_history]
+
+    cpdef column_names(self):
+        return self.thisptr.column_names()
+
+    cpdef column_types(self):
+        return [pytype_from_flex_type_enum(t) for t in self.thisptr.column_types()]
+
+    cpdef close(self):
+        cdef unity_sframe_base_ptr proxy
+        with nogil:
+            proxy = self.thisptr.close()
+        return sframe_proxy(self._cli, proxy)

--- a/oss_src/unity/python/sframe/cython/cy_unity_base_types.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_unity_base_types.pxd
@@ -41,9 +41,19 @@ cdef extern from "<unity/lib/api/unity_global_interface.hpp>" namespace 'graphla
     cdef cppclass unity_global_base:
         pass
 
+cdef extern from "<unity/lib/api/unity_sarray_builder_interface.hpp>" namespace 'graphlab':
+    cdef cppclass unity_sarray_builder_base:
+        pass
+
+cdef extern from "<unity/lib/api/unity_sframe_builder_interface.hpp>" namespace 'graphlab':
+    cdef cppclass unity_sframe_builder_base:
+        pass
+
 ctypedef shared_ptr[unity_sarray_base] unity_sarray_base_ptr
 ctypedef shared_ptr[unity_sframe_base] unity_sframe_base_ptr
 ctypedef shared_ptr[unity_sgraph_base] unity_sgraph_base_ptr
 ctypedef shared_ptr[unity_sketch_base] unity_sketch_base_ptr
 ctypedef shared_ptr[model_base] model_base_ptr
 ctypedef shared_ptr[unity_global_base] unity_global_base_ptr 
+ctypedef shared_ptr[unity_sarray_builder_base] unity_sarray_builder_base_ptr
+ctypedef shared_ptr[unity_sframe_builder_base] unity_sframe_builder_base_ptr

--- a/oss_src/unity/python/sframe/data_structures/sarray_builder.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray_builder.py
@@ -1,0 +1,147 @@
+"""
+An interface for creating an SArray over time.
+"""
+
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the DATO-PYTHON-LICENSE file for details.
+'''
+
+from ..connect import main as glconnect
+from ..cython.cy_sarray_builder import UnitySArrayBuilderProxy
+from .sarray import SArray
+
+class SArrayBuilder(object):
+    """
+    An interface to incrementally build an SArray element by element.
+
+    Once closed, the SArray cannot be "reopened" using this interface.
+
+    Parameters
+    ----------
+    num_segments : int, optional
+        Number of segments that can be written in parallel.
+
+    history_size : int, optional
+        The number of elements to be cached as history. Caches the last
+        `history_size` elements added with `append` or `append_multiple`.
+
+    dtype : type, optional
+        The type the resulting SArray will be. If None, the resulting SArray
+        will take on the type of the first non-None value it receives.
+        
+    Returns
+    -------
+    out : SArrayBuilder
+
+    Examples
+    --------
+    >>> from graphlab import SArrayBuilder
+
+    >>> sb = SArrayBuilder()
+
+    >>> sb.append(1)
+
+    >>> sb.append([2,3])
+
+    >>> sb.close()
+    dtype: int
+    Rows: 3
+    [1, 2, 3]
+
+    """
+    def __init__(self, num_segments=1, history_size=10, dtype=None):
+        self._builder = UnitySArrayBuilderProxy(glconnect.get_client())
+        if dtype is None:
+            dtype = type(None)
+        self._builder.init(num_segments, history_size, dtype)
+        self._block_size = 1024
+
+    def append(self, data, segment=0):
+        """
+        Append a single element to an SArray.
+
+        Throws a RuntimeError if the type of `data` is incompatible with
+        the type of the SArray. 
+
+        Parameters
+        ----------
+        data  : any SArray-supported type
+            A data element to add to the SArray.
+
+        segment : int
+            The segment to write this element. Each segment is numbered
+            sequentially, starting with 0. Any value in segment 1 will be after
+            any value in segment 0, and the order of elements in each segment is
+            preserved as they are added.
+        """
+        self._builder.append(data, segment)
+        
+    def append_multiple(self, data, segment=0):
+        """
+        Append multiple elements to an SArray.
+
+        Throws a RuntimeError if the type of `data` is incompatible with
+        the type of the SArray. 
+
+        Parameters
+        ----------
+        data  : any SArray-supported type
+            A data element to add to the SArray.
+
+        segment : int
+            The segment to write this element. Each segment is numbered
+            sequentially, starting with 0. Any value in segment 1 will be after
+            any value in segment 0, and the order of elements in each segment is
+            preserved as they are added.
+        """
+        if not hasattr(data, '__iter__'):
+            raise TypeError("append_multiple must be passed an iterable object")
+        tmp_list = []
+        block_pos = 0
+        first = True
+        while block_pos == self._block_size or first:
+            first = False
+            for i in data:
+                tmp_list.append(i)
+                ++block_pos
+                if block_pos == self._block_size:
+                    break
+            self._builder.append_multiple(tmp_list, segment)
+            tmp_list = []
+
+    def get_type(self):
+        """
+        The type the result SArray will be if `close` is called.
+        """
+        return self._builder.get_type()
+
+    def read_history(self, num=10):
+        """
+        Outputs the last `num` elements that were appended either by `append` or
+        `append_multiple`.
+
+        Returns
+        -------
+        out : list
+
+        """
+        if num < 0:
+          num = 0
+        return self._builder.read_history(num)
+
+    def close(self):
+        """
+        Creates an SArray from all values that were appended to the
+        SArrayBuilder. No function that appends data may be called after this
+        is called.
+
+        Returns
+        -------
+        out : SArray
+
+        """
+        return SArray(_proxy=self._builder.close())

--- a/oss_src/unity/python/sframe/data_structures/sframe.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe.py
@@ -19,7 +19,8 @@ from ..connect import main as glconnect
 from ..cython.cy_flexible_type import infer_type_of_list
 from ..cython.context import debug_trace as cython_context
 from ..cython.cy_sframe import UnitySFrameProxy
-from ..util import _make_internal_url
+from ..util import _make_internal_url, infer_dbapi2_types
+from ..util import get_module_from_object, pytype_to_printf
 from .sarray import SArray, _create_sequential_sarray
 from .. import aggregate
 from .image import Image as _Image
@@ -209,6 +210,59 @@ def load_sframe(filename):
     sf = SFrame(data=filename)
     return sf
 
+def _get_global_dbapi_info(dbapi_module, conn):
+    """
+    Fetches all needed information from the top-level DBAPI module,
+    guessing at the module if it wasn't passed as a parameter. Returns a
+    dictionary of all the needed variables. This is put in one place to
+    make sure the error message is clear if the module "guess" is wrong.
+    """
+    module_given_msg = "The DBAPI2 module given ({0}) is missing the global\n"+\
+    "variable '{1}'. Please make sure you are supplying a module that\n"+\
+    "conforms to the DBAPI 2.0 standard (PEP 0249)."
+    module_not_given_msg = "Hello! I gave my best effort to find the\n"+\
+    "top-level module that the connection object you gave me came from.\n"+\
+    "I found '{0}' which doesn't have the global variable '{1}'.\n"+\
+    "To avoid this confusion, you can pass the module as a parameter using\n"+\
+    "the 'dbapi_module' argument to either from_sql or to_sql."
+
+    if dbapi_module is None:
+        dbapi_module = get_module_from_object(conn)
+        module_given = False
+    else:
+        module_given = True
+
+    module_name = dbapi_module.__name__ if hasattr(dbapi_module, '__name__') else None
+
+    needed_vars = ['apilevel','paramstyle','DATETIME','NUMBER','ROWID']
+    ret_dict = {}
+
+    for i in needed_vars:
+        try:
+            tmp = eval("dbapi_module."+i)
+        except AttributeError as e:
+            if module_given:
+                raise AttributeError(module_given_msg.format(module_name, i))
+            else:
+                raise AttributeError(module_not_given_msg.format(module_name, i))
+        ret_dict[i] = tmp
+
+    try:
+        if ret_dict['apilevel'][0:3] != "2.0":
+            raise NotImplementedError("Unsupported API version " +\
+              str(ret_dict['apilevel']) + ". Only DBAPI 2.0 is supported.")
+    except TypeError as e:
+        e.message = "Module's 'apilevel' value is invalid."
+        raise e
+
+    acceptable_paramstyles = ['qmark','numeric','named','format','pyformat']
+    try:
+        if ret_dict['paramstyle'] not in acceptable_paramstyles:
+            raise TypeError("Module's 'paramstyle' value is invalid.")
+    except TypeError as e:
+        raise TypeError("Module's 'paramstyle' value is invalid.")
+
+    return ret_dict
 
 class SFrame(object):
     """
@@ -2046,6 +2100,209 @@ class SFrame(object):
 
         if (not verbose):
             glconnect.get_client().set_log_progress(True)
+
+    @classmethod
+    def from_sql(cls, conn, sql_statement, params=None, type_inference_rows=100,
+        dbapi_module=None, column_type_hints=None):
+        """
+        Convert the result of a SQL database query to an SFrame.
+
+        Parameters
+        ----------
+        conn : dbapi2.Connection
+          A DBAPI2 connection object. Any connection object originating from
+          the 'connect' method of a DBAPI2-compliant package can be used.
+
+        sql_statement : str
+          The query to be sent to the database through the given connection.
+          No checks are performed on the `sql_statement`. Any side effects from
+          the query will be reflected on the database.  If no result rows are
+          returned, an empty SFrame is created.
+
+        params : iterable | dict, optional
+          Parameters to substitute for any parameter markers in the
+          `sql_statement`. Be aware that the style of parameters may vary
+          between different DBAPI2 packages.
+
+        type_inference_rows : int, optional
+          The maximum number of rows to use for determining the column types of
+          the SFrame. These rows are held in Python until all column types are
+          determined or the maximum is reached.
+
+        dbapi_module : module | package, optional
+          The top-level DBAPI2 module/package that constructed the given
+          connection object. By default, a best guess of which module the
+          connection came from is made. In the event that this guess is wrong,
+          this will need to be specified.
+
+        column_type_hints : dict | list | type, optional
+          Specifies the types of the output SFrame. If a dict is given, it must
+          have result column names as keys, but need not have all of the result
+          column names. If a list is given, the length of the list must match
+          the number of result columns. If a single type is given, all columns
+          in the output SFrame will be this type. If the result type is
+          incompatible with the types given in this argument, a casting error
+          will occur.
+
+        Returns
+        -------
+        out : SFrame
+
+        Examples
+        --------
+        >>> import sqlite3
+
+        >>> conn = sqlite3.connect('example.db')
+
+        >>> graphlab.SFrame.from_sql(conn, "SELECT * FROM foo")
+        Columns:
+                a       int
+                b       int
+        Rows: 1
+        Data:
+        +---+---+
+        | a | b |
+        +---+---+
+        | 1 | 2 |
+        +---+---+
+        [1 rows x 2 columns]
+        """
+        mod_info = _get_global_dbapi_info(dbapi_module, conn)
+
+        from .sframe_builder import SFrameBuilder
+
+        c = conn.cursor()
+        c.execute(sql_statement, params)
+        result_desc = c.description
+        result_names = [i[0] for i in result_desc]
+        result_types = [None for i in result_desc]
+
+        # Set any types that are given to us
+        col_name_to_num = {result_names[i]:i for i in range(len(result_names))}
+        if column_type_hints is not None:
+            if type(column_type_hints) is dict:
+                for k,v in column_type_hints.iteritems():
+                    result_types[col_name_to_num[k]] = v
+            elif type(column_type_hints) is list:
+                if len(column_type_hints) != len(result_names):
+                    __LOGGER__.warn("If column_type_hints is specified as a "+\
+                        "list, it must be of the same size as the result "+\
+                        "set's number of columns. Ignoring (use dict instead).")
+                else:
+                    result_types = column_type_hints
+            elif type(column_type_hints) is type:
+                result_types = [column_type_hints for i in result_desc]
+
+        temp_vals = []
+
+        # Perform type inference by checking to see what python types are
+        # returned from the cursor
+        if not all(result_types):
+            # Hmm...an iterable cursor is not *technically* required by the
+            # DBAPI2 standard. Consider switching.
+            for row in c:
+                # Assumes that things like dicts are not a "single sequence"
+                temp_vals.append(row)
+                val_count = 0
+                for val in row:
+                    if result_types[val_count] is None and val is not None:
+                        result_types[val_count] = type(val)
+                    val_count += 1
+                if all(result_types) or len(temp_vals) >= type_inference_rows:
+                    break
+
+        # This will be true if some columns have all missing values up to this
+        # point. Try using DBAPI2 type_codes to pick a suitable type. If this
+        # doesn't work, fall back to string.
+        if not all(result_types):
+            inferred_types = infer_dbapi2_types(c, mod_info)
+            cnt = 0
+            for i in result_types:
+                if i is None:
+                    result_types[cnt] = inferred_types[cnt]
+                cnt += 1
+
+        sb = SFrameBuilder(result_types, column_names=result_names)
+        sb.append_multiple(temp_vals)
+        sb.append_multiple(c)
+        cls = sb.close()
+        c.close()
+        return cls
+
+    def to_sql(self, conn, table_name, dbapi_module=None, use_python_type_specifiers=False):
+        """
+        Convert an SFrame to a single table in a SQL database.
+
+        This function does not attempt to create the table or check if a table
+        named `table_name` exists in the database. It simply assumes that
+        `table_name` exists in the database and appends to it.
+
+        `to_sql` can be thought of as a convenience wrapper around
+        parameterized SQL insert statements.
+
+        Parameters
+        ----------
+        conn : dbapi2.Connection
+          A DBAPI2 connection object. Any connection object originating from
+          the 'connect' method of a DBAPI2-compliant package can be used.
+
+        table_name : str
+          The name of the table to append the data in this SFrame.
+
+        dbapi_module : module | package, optional
+          The top-level DBAPI2 module/package that constructed the given
+          connection object. By default, a best guess of which module the
+          connection came from is made. In the event that this guess is wrong,
+          this will need to be specified.
+
+        use_python_type_specifiers : bool, optional
+          If the DBAPI2 module's parameter marker style is 'format' or
+          'pyformat', attempt to use accurate type specifiers for each value
+          ('s' for string, 'd' for integer, etc.). Many DBAPI2 modules simply
+          use 's' for all types if they use these parameter markers, so this is
+          False by default.
+        """
+        mod_info = _get_global_dbapi_info(dbapi_module, conn)
+        c = conn.cursor()
+
+        col_info = zip(self.column_names(), self.column_types())
+
+        if not use_python_type_specifiers:
+            pytype_to_printf = lambda x: 's'
+
+        # DBAPI2 standard allows for five different ways to specify parameters
+        sql_param = {
+            'qmark'   : lambda name,col_num,col_type: '?',
+            'numeric' : lambda name,col_num,col_type:':'+str(col_num+1),
+            'named'   : lambda name,col_num,col_type:':'+str(name),
+            'format'  : lambda name,col_num,col_type:'%'+pytype_to_printf(col_type),
+            'pyformat': lambda name,col_num,col_type:'%('+str(name)+')'+pytype_to_printf(col_type),
+            }
+
+        get_sql_param = sql_param[mod_info['paramstyle']]
+        
+        # form insert string
+        ins_str = "INSERT INTO " + str(table_name) + " VALUES ("
+        count = 0
+        for i in col_info:
+            ins_str += get_sql_param(i[0],count,i[1])
+            if count < len(col_info)-1:
+                ins_str += ","
+            count += 1
+        ins_str += ")"
+
+        # Some formats require values in an iterable, some a dictionary
+        if (mod_info['paramstyle'] == 'named' or\
+            mod_info['paramstyle'] == 'pyformat'):
+          prepare_sf_row = lambda x:x
+        else:
+          prepare_sf_row = lambda x:x.values()
+
+        for i in self:
+            c.execute(ins_str, prepare_sf_row(i))
+
+        conn.commit()
+        c.close()
 
     def __repr__(self):
         """

--- a/oss_src/unity/python/sframe/data_structures/sframe_builder.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe_builder.py
@@ -1,0 +1,181 @@
+"""
+An interface for creating an SFrame over time.
+"""
+
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the DATO-PYTHON-LICENSE file for details.
+'''
+
+from ..connect import main as glconnect
+from ..cython.cy_sframe_builder import UnitySFrameBuilderProxy
+from .sframe import SFrame 
+
+class SFrameBuilder(object):
+    """
+    An interface to incrementally build an SFrame (row by row). It has some
+    basic features such as appending multiple rows at once, polling the last N
+    rows appended, and a primitive parallel insert interface.
+
+    Once closed, the SFrame cannot be "reopened" using this interface.
+
+    Parameters
+    ----------
+    column_types : list[type]
+        The column types of the result SFrame. Types must be of the python
+        types that are supported by SFrame (int, float, str, array.array, list,
+        dict, datetime.datetime, image). Column types are strictly enforced
+        while appending.
+
+    column_names : list[str], optional
+        Column names of the result SFrame. If given, length of the list must
+        equal the length of `column_types`. If not given, names are generated.
+
+    num_segments : int, optional
+        Number of segments that can be written in parallel.
+
+    history_size : int, optional
+        The number of rows to be cached as history. Caches the last
+        `history_size` rows added with `append` or `append_multiple`.
+
+    Returns
+    -------
+    out : SFrameBuilder
+
+    Examples
+    --------
+    >>> from graphlab import SFrameBuilder
+
+    >>> sb = SFrameBuilder([int,float,str])
+
+    >>> sb.append([1,1.0,"1"])
+
+    >>> sb.append_multiple([[2,2.0,"2"],[3,3.0,"3"]])
+
+    >>> sb.close()
+    Columns:
+            X1      int
+            X2      float
+            X3      str
+    Rows: 3
+    Data:
+    +----+-----+----+
+    | X1 |  X2 | X3 |
+    +----+-----+----+
+    | 1  | 1.0 | 1  |
+    | 2  | 2.0 | 2  |
+    | 3  | 3.0 | 3  |
+    +----+-----+----+
+    [3 rows x 3 columns]
+
+    """
+    def __init__(self, column_types, column_names=None, num_segments=1, history_size=10):
+        self._column_names = column_names
+        self._column_types = column_types
+        self._num_segments = num_segments
+        self._history_size = history_size
+        if column_names is not None and column_types is not None:
+            if len(column_names) != len(column_types):
+                raise AssertionError("There must be same amount of column names as column types.")
+        elif column_names is None and column_types is not None:
+            self._column_names = self._generate_column_names(len(column_types))
+        else:
+            raise AssertionError("Column types must be defined!")
+
+        self._builder = UnitySFrameBuilderProxy(glconnect.get_client())
+        self._builder.init(self._column_types, self._column_names, self._num_segments, self._history_size)
+        self._block_size = 1024
+
+    def _generate_column_names(self, num_columns):
+        return ["X"+str(i) for i in range(1,num_columns+1)]
+
+    def append(self, data, segment=0):
+        """
+        Append a single row to an SFrame.
+
+        Throws a RuntimeError if one or more column's type is incompatible with
+        a type appended.
+
+        Parameters
+        ----------
+        data  : iterable
+            An iterable representation of a single row.
+
+        segment : int
+            The segment to write this row. Each segment is numbered
+            sequentially, starting with 0. Any value in segment 1 will be after
+            any value in segment 0, and the order of rows in each segment is
+            preserved as they are added.
+        """
+        # Assume this case refers to an SFrame with a single column
+        if not hasattr(data, '__iter__'):
+            data = [data]
+        self._builder.append(data, segment)
+
+    def append_multiple(self, data, segment=0):
+        """
+        Append multiple rows to an SFrame.
+
+        Throws a RuntimeError if one or more column's type is incompatible with
+        a type appended.
+
+        Parameters
+        ----------
+        data  : iterable[iterable]
+            A collection of multiple iterables, each representing a single row.
+
+        segment : int
+            The segment to write the given rows. Each segment is numbered
+            sequentially, starting with 0. Any value in segment 1 will be after
+            any value in segment 0, and the order of rows in each segment is
+            preserved as they are added.
+        """
+        if not hasattr(data, '__iter__'):
+            raise TypeError("append_multiple must be passed an iterable object")
+        tmp_list = []
+        block_pos = 0
+        first = True
+        while block_pos == self._block_size or first:
+            first = False
+            for i in data:
+                tmp_list.append(i)
+                ++block_pos
+                if block_pos == self._block_size:
+                    break
+            self._builder.append_multiple(tmp_list, segment)
+            tmp_list = []
+
+    def column_names(self):
+        return self._builder.column_names()
+
+    def column_types(self):
+        return self._builder.column_types()
+
+    def read_history(self, num=10):
+        """
+        Outputs the last `num` rows that were appended either by `append` or
+        `append_multiple`.
+
+        Returns
+        -------
+        out : list[list]
+        """
+        if num < 0:
+          num = 0
+        return self._builder.read_history(num)
+
+    def close(self):
+        """
+        Creates an SFrame from all values that were appended to the
+        SFrameBuilder. No function that appends data may be called after this
+        is called.
+
+        Returns
+        -------
+        out : SFrame
+        """
+        return SFrame(_proxy=self._builder.close())
+

--- a/oss_src/unity/python/sframe/test/dbapi2_mock/__init__.py
+++ b/oss_src/unity/python/sframe/test/dbapi2_mock/__init__.py
@@ -1,0 +1,19 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+
+class dbapi2_mock(object):
+    def __init__(self):
+        # Mandated globals
+        self.apilevel = "2.0 "
+        self.threadsafety = 3
+        self.paramstyle = 'qmark'
+        self.STRING = 41
+        self.BINARY = 42
+        self.DATETIME = 43
+        self.NUMBER = 44
+        self.ROWID = 45

--- a/oss_src/unity/python/sframe/test/test_sarray_builder.py
+++ b/oss_src/unity/python/sframe/test/test_sarray_builder.py
@@ -1,0 +1,94 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+
+from ..data_structures.sarray_builder import SArrayBuilder
+import unittest
+import array
+import datetime as dt
+from ..util.timezone import GMT
+
+class SArrayBuilderTest(unittest.TestCase):
+    def __test_equal(self, _sarray, _data, _type):
+        self.assertEqual(_sarray.dtype(), _type)
+        self.assertEqual(len(_sarray), len(_data))
+        self.assertSequenceEqual(list(_sarray.head(_sarray.size())), _data)
+
+    def __test_append(self, sb, data, dtype):
+        for i in data:
+            sb.append(i)
+        self.assertEquals(sb.get_type(), dtype)
+        sa = sb.close()
+        self.__test_equal(sa, data, dtype)
+
+    def __test_append_multiple(self, sb, data, dtype):
+        sb.append_multiple(data)
+        self.assertEquals(sb.get_type(), dtype)
+        sa = sb.close()
+        self.__test_equal(sa, data, dtype)
+
+    def test_basic(self):
+        data_to_test = [([1,-1,None,2],int),
+                        ([i for i in range(20000)], int),
+                        ([None, 1.0, -1.0, 2.3],float),
+                        (["hi", None, "hello", "None"],str),
+                        ([dt.datetime(2013, 5, 7, 10, 4, 10),
+                          dt.datetime(1902, 10, 21, 10, 34, 10).replace(tzinfo=GMT(0.0)),None],dt.datetime),
+                        ([["hi",1],None,["hi",2,3],["hello"]],list),
+                        ([array.array('d',[1.0,2.0]),array.array('d',[3.0,4.0]),None],array.array),
+                        ([{'a':1,'b':2},{'c':3,'d':4},None],dict),
+                        ]
+        for i in data_to_test:
+            sb = SArrayBuilder()
+            self.__test_append(sb, i[0], i[1])
+
+            sb = SArrayBuilder()
+            self.__test_append_multiple(sb, i[0], i[1])
+
+            sb = SArrayBuilder(dtype=i[1])
+            self.__test_append(sb, i[0], i[1])
+
+            sb = SArrayBuilder(dtype=i[1])
+            self.__test_append_multiple(sb, i[0], i[1])
+
+    def test_history(self):
+        sb = SArrayBuilder(history_size=10)
+        sb.append_multiple((i for i in xrange(8)))
+        hist = sb.read_history(3)
+        self.assertEquals(hist,[5,6,7])
+
+        hist = sb.read_history(20)
+        self.assertEquals(hist, [i for i in range(8)])
+        hist = sb.read_history()
+        self.assertEquals(hist, [i for i in range(8)])
+
+        sb.append_multiple((i for i in xrange(5)))
+        hist = sb.read_history(10)
+        self.assertEquals(hist, [3,4,5,6,7,0,1,2,3,4])
+
+        sb.append(50)
+        hist = sb.read_history(10)
+        self.assertEquals(hist, [4,5,6,7,0,1,2,3,4,50])
+
+        hist = sb.read_history(-1)
+        self.assertEquals(hist, [])
+        hist = sb.read_history(0)
+        self.assertEquals(hist, [])
+
+        sa = sb.close()
+        self.__test_equal(sa,[i for i in range(8)] + [i for i in range(5)] + [50],int)
+
+    def test_segments(self):
+        sb = SArrayBuilder(num_segments=4)
+
+        sb.append_multiple((i for i in xrange(20,30)), segment=2)
+        sb.append_multiple((i for i in xrange(10,20)), segment=1)
+        sb.append_multiple((i for i in xrange(30,40)), segment=3)
+        sb.append_multiple((i for i in xrange(0,10)), segment=0)
+
+        sa = sb.close()
+        self.__test_equal(sa, range(40), int)

--- a/oss_src/unity/python/sframe/test/test_sframe.py
+++ b/oss_src/unity/python/sframe/test/test_sframe.py
@@ -32,6 +32,9 @@ import random
 import shutil
 import functools
 import sys
+import mock
+import sqlite3
+from dbapi2_mock import dbapi2_mock
 HAS_PYSPARK = True
 try:
     from pyspark import SparkContext, SQLContext
@@ -64,6 +67,20 @@ class SFrameTest(unittest.TestCase):
         self.float_data2 = [1.0 * i for i in range(50,60)]
         self.string_data2 = [str(i) for i in range(50,60)]
         self.dataframe2 = pd.DataFrame({'int_data': self.int_data2, 'float_data': self.float_data2, 'string_data': self.string_data2})
+        self.vec_data = [array.array('d', [i, i+1]) for i in self.int_data]
+        self.list_data = [[i, str(i), i * 1.0] for i in self.int_data]
+        self.dict_data =  [{str(i): i, i : float(i)} for i in self.int_data]
+        self.datetime_data = [dt.datetime(2013, 5, 7, 10, 4, 10),
+                dt.datetime(1902, 10, 21, 10, 34, 10).replace(tzinfo=GMT(0.0))]
+        self.all_type_cols = [self.int_data,
+                              self.float_data,
+                              self.string_data,
+                              self.vec_data,
+                              self.list_data,
+                              self.dict_data,
+                              self.datetime_data*5]
+        self.sf_all_types = SFrame({"X"+str(i[0]):i[1] for i in zip(range(1,8),
+          self.all_type_cols)})
 
         # Taken from http://en.wikipedia.org/wiki/Join_(SQL) for fun.
         self.employees_sf = SFrame()
@@ -3024,6 +3041,149 @@ class SFrameTest(unittest.TestCase):
         Y = np.transpose(np.array([s, s]))
         nptest.assert_array_equal(X.to_numpy(), Y)
 
+    @mock.patch(__name__+'.sqlite3.Cursor', spec=True)
+    @mock.patch(__name__+'.sqlite3.Connection', spec=True)
+    def test_from_sql(self, mock_conn, mock_cursor):
+        conn = mock_conn('example.db')
+
+        curs = mock_cursor()
+        conn.cursor.return_value = curs
+        sf_type_codes = [44,44,41,22,114,199,43]
+        sf_data = zip(*self.all_type_cols)
+        curs.description = [['X'+str(i+1),sf_type_codes[i]]+[None for j in range(5)] for i in range(len(sf_data[0]))]
+        curs.__iter__.return_value = sf_data.__iter__()
+
+        # bigger than cache, no Nones
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", type_inference_rows=5, dbapi_module=dbapi2_mock())
+        _assert_sframe_equal(sf, self.sf_all_types)
+
+        # smaller than cache, no Nones
+        curs.__iter__.return_value = sf_data.__iter__()
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", type_inference_rows=100, dbapi_module=dbapi2_mock())
+        _assert_sframe_equal(sf, self.sf_all_types)
+
+        none_col = [None for i in range(5)]
+        nones_in_cache = zip(*[none_col for i in range(len(sf_data[0]))])
+        none_sf = SFrame({'X'+str(i):none_col for i in range(1,len(sf_data[0])+1)})
+        test_data = (nones_in_cache+sf_data)
+        curs.__iter__.return_value = test_data.__iter__()
+
+        # more None rows than cache & types in description
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", type_inference_rows=5, dbapi_module=dbapi2_mock())
+        sf_inferred_types = SFrame()
+        expected_types = [float,float,str,str,str,str,dt.datetime]
+        for i in zip(self.sf_all_types.column_names(),expected_types):
+            new_col = SArray(none_col).astype(i[1])
+            new_col = new_col.append(self.sf_all_types[i[0]].astype(i[1]))
+            sf_inferred_types.add_column(new_col)
+        _assert_sframe_equal(sf, sf_inferred_types)
+
+        # more None rows than cache & no type information
+        for i in range(len(curs.description)):
+            curs.description[i][1] = None
+        curs.__iter__.return_value = test_data.__iter__()
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", type_inference_rows=5, dbapi_module=dbapi2_mock())
+
+        expected_types = [str for i in range(len(sf_data[0]))]
+        for i in zip(self.sf_all_types.column_names(),expected_types):
+            sf_inferred_types[i[0]] = sf_inferred_types[i[0]].astype(i[1])
+        _assert_sframe_equal(sf, sf_inferred_types)
+
+        ### column_type_hints tests
+        curs.__iter__.return_value = test_data.__iter__()
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", type_inference_rows=5,
+            dbapi_module=dbapi2_mock(), column_type_hints=str)
+        _assert_sframe_equal(sf, sf_inferred_types)
+
+        curs.__iter__.return_value = test_data.__iter__()
+        expected_types = [int,float,str,array.array,list,dict,dt.datetime]
+        sf = SFrame.from_sql(conn,
+            "SELECT * FROM test_table", type_inference_rows=5,
+            dbapi_module=dbapi2_mock(), column_type_hints=expected_types)
+        _assert_sframe_equal(sf[5:],self.sf_all_types)
+
+        curs.__iter__.return_value = test_data.__iter__()
+        expected_types = {'X'+str(i+1):expected_types[i] for i in range(len(expected_types))}
+        sf = SFrame.from_sql(conn,
+            "SELECT * FROM test_table", type_inference_rows=5,
+            dbapi_module=dbapi2_mock(), column_type_hints=expected_types)
+        _assert_sframe_equal(sf[5:],self.sf_all_types)
+
+        curs.__iter__.return_value = test_data.__iter__()
+        del expected_types['X2']
+        del expected_types['X4']
+        self.sf_all_types['X2'] = self.sf_all_types['X2'].astype(str)
+        self.sf_all_types['X4'] = self.sf_all_types['X4'].astype(str)
+        sf = SFrame.from_sql(conn,
+            "SELECT * FROM test_table", type_inference_rows=5,
+            dbapi_module=dbapi2_mock(), column_type_hints=expected_types)
+        _assert_sframe_equal(sf[5:],self.sf_all_types)
+
+        # bad DBAPI version!
+        bad_version = dbapi2_mock()
+        bad_version.apilevel = "1.0 "
+        with self.assertRaises(NotImplementedError):
+            sf = SFrame.from_sql(conn, "SELECT * FROM test_table", dbapi_module=bad_version)
+
+        # Bad module
+        with self.assertRaises(AttributeError):
+            sf = SFrame.from_sql(conn, "SELECT * FROM test_table", dbapi_module=os)
+
+        # Bad connection
+        with self.assertRaises(AttributeError):
+            sf = SFrame.from_sql(4, "SELECT * FROM test_table")
+
+        # Empty query result
+        curs.description = []
+        sf = SFrame.from_sql(conn, "SELECT * FROM test_table", dbapi_module=dbapi2_mock())
+        _assert_sframe_equal(sf, SFrame())
+
+    @mock.patch(__name__+'.sqlite3.Cursor', spec=True)
+    @mock.patch(__name__+'.sqlite3.Connection', spec=True)
+    def test_to_sql(self, mock_conn, mock_cursor):
+        conn = mock_conn('example.db')
+        curs = mock_cursor()
+        insert_stmt = "INSERT INTO ins_test VALUES ({0},{1},{2},{3},{4},{5},{6})"
+        num_cols = len(self.sf_all_types.column_names())
+        test_cases = [
+            ('qmark',insert_stmt.format(*['?' for i in range(num_cols)])),
+            ('numeric',insert_stmt.format(*[':'+str(i) for i in range(1,num_cols+1)])),
+            ('named',insert_stmt.format(*[':X'+str(i) for i in range(1,num_cols+1)])),
+            ('format',insert_stmt.format(*['%s' for i in range(num_cols)])),
+            ('pyformat',insert_stmt.format(*['%(X'+str(i)+')s' for i in range(1,num_cols+1)])),
+              ]
+        for i in test_cases:
+            conn.cursor.return_value = curs
+
+            mock_mod = dbapi2_mock()
+            mock_mod.paramstyle = i[0]
+            self.sf_all_types.to_sql(conn, "ins_test", dbapi_module=mock_mod)
+            conn.cursor.assert_called_once_with()
+            calls = []
+            for j in self.sf_all_types:
+                if i[0] == 'named' or i[0] == 'pyformat':
+                    calls.append(mock.call(i[1],j))
+                else:
+                    calls.append(mock.call(i[1],j.values()))
+            curs.execute.assert_has_calls(calls, any_order=False)
+            self.assertEquals(curs.execute.call_count, len(self.sf_all_types))
+            conn.commit.assert_called_once_with()
+            curs.close.assert_called_once_with()
+
+            conn.reset_mock()
+            curs.reset_mock()
+
+        # bad DBAPI version!
+        bad_version = dbapi2_mock()
+        bad_version.apilevel = "1.0 "
+        with self.assertRaises(NotImplementedError):
+            self.sf_all_types.to_sql(conn, "ins_test", dbapi_module=bad_version)
+
+        # bad paramstyle
+        bad_paramstyle = dbapi2_mock()
+        bad_paramstyle.paramstyle = 'foo'
+        with self.assertRaises(TypeError):
+            self.sf_all_types.to_sql(conn, "ins_test", dbapi_module=bad_version)
 if __name__ == "__main__":
 
     import sys

--- a/oss_src/unity/python/sframe/test/test_sframe_builder.py
+++ b/oss_src/unity/python/sframe/test/test_sframe_builder.py
@@ -1,0 +1,98 @@
+'''
+Copyright (C) 2015 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+
+from ..data_structures.sframe import SFrame
+import unittest
+import array
+import datetime as dt
+from ..util.timezone import GMT
+from ..util import _assert_sframe_equal
+
+class SFrameBuilderTest(unittest.TestCase):
+    def setUp(self):
+        self.int_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        self.float_data = [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]
+        self.string_data = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+        self.vec_data = [array.array('d', [i, i+1]) for i in self.int_data]
+        self.list_data = [[i, str(i), i * 1.0] for i in self.int_data]
+        self.dict_data =  [{str(i): i, i : float(i)} for i in self.int_data]
+        self.datetime_data = [dt.datetime(2013, 5, 7, 10, 4, 10),
+                dt.datetime(1902, 10, 21, 10, 34, 10).replace(tzinfo=GMT(0.0))]
+        self.all_type_cols = [self.int_data,
+                              self.float_data,
+                              self.string_data,
+                              self.vec_data,
+                              self.list_data,
+                              self.dict_data,
+                              self.datetime_data*5]
+        self.sf_all_types = SFrame({"X"+str(i[0]):i[1] for i in zip(range(1,8),
+          self.all_type_cols)})
+        self.all_types = [int,float,str,array.array,list,dict,dt.datetime]
+
+    def test_basic(self):
+        from ..data_structures.sframe_builder import SFrameBuilder
+        sf_data = zip(*self.all_type_cols) 
+
+        sb = SFrameBuilder(self.all_types)
+        for i in sf_data:
+            sb.append(i)
+        sf = sb.close()
+        _assert_sframe_equal(sf, self.sf_all_types)
+
+        sb = SFrameBuilder(self.all_types)
+        sb.append_multiple(sf_data)
+        sf = sb.close()
+        _assert_sframe_equal(sf, self.sf_all_types)
+
+    def test_history(self):
+        from ..data_structures.sframe_builder import SFrameBuilder
+        sb = SFrameBuilder([int,float], history_size=10)
+        sb.append_multiple(([i,i+0.0] for i in xrange(8)))
+        hist = sb.read_history(3)
+        self.assertEquals(hist,[[5,5.0],[6,6.0],[7,7.0]])
+
+        hist = sb.read_history(20)
+        self.assertEquals(hist, [[i,i+0.0] for i in range(8)])
+        hist = sb.read_history()
+        self.assertEquals(hist, [[i,i+0.0] for i in range(8)])
+
+        sb.append_multiple(([i,i+0.0] for i in xrange(5)))
+        hist = sb.read_history(10)
+        self.assertEquals(hist, [[i,i+0.0] for i in [3,4,5,6,7,0,1,2,3,4]])
+
+        sb.append([50,50.0])
+        hist = sb.read_history(10)
+        self.assertEquals(hist, [[i,i+0.0] for i in [4,5,6,7,0,1,2,3,4,50]])
+
+        hist = sb.read_history(-1)
+        self.assertEquals(hist, [])
+        hist = sb.read_history(0)
+        self.assertEquals(hist, [])
+
+        expected_data = [[i,i+0.0] for i in range(8)] + [[i,i+0.0] for i in range(5)] + [[50,50.0]]
+        cols = [[],[]]
+        for i in expected_data:
+            cols[0].append(i[0])
+            cols[1].append(i[1])
+        expected_sf = SFrame({'X1':cols[0],'X2':cols[1]})
+
+        sf = sb.close()
+        _assert_sframe_equal(sf,expected_sf)
+
+    def test_segments(self):
+        from ..data_structures.sframe_builder import SFrameBuilder
+        sb = SFrameBuilder([int],num_segments=4)
+
+        sb.append_multiple(([i] for i in xrange(20,30)), segment=2)
+        sb.append_multiple(([i] for i in xrange(10,20)), segment=1)
+        sb.append_multiple(([i] for i in xrange(30,40)), segment=3)
+        sb.append_multiple(([i] for i in xrange(0,10)), segment=0)
+
+        sf = sb.close()
+        expected_sf = SFrame({'X1':range(40)})
+        _assert_sframe_equal(sf, expected_sf)

--- a/oss_src/unity/python/sframe/test/util.py
+++ b/oss_src/unity/python/sframe/test/util.py
@@ -15,6 +15,7 @@ import math
 import string
 import numpy as np
 from pandas.util.testing import assert_frame_equal
+import sqlite3
 
 from ..connect import server as server
 from .. import SArray

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -833,3 +833,42 @@ def get_client_log_location():
 
 def get_server_log_location():
     return get_log_location()
+
+def get_module_from_object(obj):
+    mod_str = obj.__class__.__module__.split('.')[0]
+    return _sys.modules[mod_str]
+
+def infer_dbapi2_types(cursor, mod_info):
+    desc = cursor.description
+    result_set_types = [i[1] for i in desc]
+    dbapi2_to_python = [ # a type code can match more than one, so ordered by
+                         # preference (loop short-circuits when it finds a match
+                        (mod_info['DATETIME'], _datetime.datetime),
+                        (mod_info['ROWID'],int),
+                        (mod_info['NUMBER'],float),
+                       ]
+    ret_types = []
+
+    # Ugly nested loop because the standard only guarantees that a type code
+    # will compare equal to the module-defined types
+    for i in result_set_types:
+        type_found = False
+        for j in dbapi2_to_python:
+            if i is None:
+                break
+            elif i == j[0]:
+                ret_types.append(j[1])
+                type_found = True
+                break 
+        if not type_found:
+            ret_types.append(str)
+
+    return ret_types
+
+def pytype_to_printf(in_type):
+    if in_type == int:
+        return 'd'
+    elif in_type == float:
+        return 'f'
+    else:
+        return 's'

--- a/oss_src/unity/server/unity_server.cpp
+++ b/oss_src/unity/server/unity_server.cpp
@@ -22,6 +22,8 @@
 #include <unity/lib/unity_sframe.hpp>
 #include <unity/lib/unity_sarray.hpp>
 #include <unity/lib/unity_sketch.hpp>
+#include <unity/lib/unity_sarray_builder.hpp>
+#include <unity/lib/unity_sframe_builder.hpp>
 #include <unity/lib/version.hpp>
 #include <unity/lib/simple_model.hpp>
 #include <parallel/pthread_tools.hpp>
@@ -379,6 +381,12 @@ int main(int argc, char** argv) {
                                           });
   server->register_type<graphlab::unity_sketch_base>([](){ 
                                             return new graphlab::unity_sketch();
+                                          });
+  server->register_type<graphlab::unity_sarray_builder_base>([]()->graphlab::unity_sarray_builder_base* { 
+                                            return new graphlab::unity_sarray_builder();
+                                          });
+  server->register_type<graphlab::unity_sframe_builder_base>([]()->graphlab::unity_sframe_builder_base* { 
+                                            return new graphlab::unity_sframe_builder();
                                           });
 
 


### PR DESCRIPTION
This results in two top-level functions added to SFrame: from_sql and
to_sql. They take a DBAPI2 connection object and can convert database
results to an SFrame and write SFrame data to a database table.

This patch also includes SArrayBuilder and SFrameBuilder, which are
incremental interfaces for building SArrays and SFrames. from_sql uses
SFrameBuilder internally.