### PR TITLE
CSV Writer And Parser Fixes

### DIFF
--- a/oss_src/flexible_type/string_escape.cpp
+++ b/oss_src/flexible_type/string_escape.cpp
@@ -26,15 +26,21 @@ void escape_string(const std::string& val,
     char c = val[i];
     switch(c) {
      case '\'':
-       (*cur_out++) = escape_char;
-       (*cur_out++) = '\'';
+       if (use_quote_char && quote_char == '\'') {
+         (*cur_out++) = escape_char;
+         (*cur_out++) = '\'';
+       } else {
+         (*cur_out++) = '\'';
+       }
        break;
      case '\"':
        if (double_quote) {
          (*cur_out++) = '\"';
          (*cur_out++) = '\"';
-       } else {
+       } else if (use_quote_char && quote_char == '\"') {
          (*cur_out++) = escape_char;
+         (*cur_out++) = '\"';
+       } else {
          (*cur_out++) = '\"';
        }
        break;
@@ -72,6 +78,29 @@ void escape_string(const std::string& val,
     }
   }
   if (use_quote_char) (*cur_out++) = quote_char;
+  size_t len = cur_out - &(output[0]);
+  output_len = len;
+}
+
+void double_quote_escape(const std::string& val,
+                         std::string& output, size_t& output_len) {
+  // A maximum of 2 * input array size is needed.
+  // (every character is escaped, and quotes on both end
+  char* cur_out = &(output[0]);
+  if (output.size() < 2 * val.size()) {
+    output.resize(2 * val.size());
+  }
+  // loop through the input string
+  for (size_t i = 0; i < val.size(); ++i) {
+    char c = val[i];
+    switch(c) {
+     case '\"':
+       (*cur_out++) = '\"';
+       // pass through to write the original quote
+     default:
+       (*cur_out++) = c;
+    }
+  }
   size_t len = cur_out - &(output[0]);
   output_len = len;
 }

--- a/oss_src/flexible_type/string_escape.hpp
+++ b/oss_src/flexible_type/string_escape.hpp
@@ -30,25 +30,21 @@ size_t unescape_string(char* cal,
  *
  * \param val The string to escape
  * \param escape_char The escape character to use (recommended '\\')
+ * \param use_escape_char If true, escape character is used. Note that
+ *       if this is false, the resultant string may not always be parseable.
  * \param quote_char The quote character to use. (recommended '\"')
  * \param use_quote_char If the output string should be quoted
  * \param double_quote If double quotes are converted to single quotes.
  */
 void escape_string(const std::string& val, 
                    char escape_char,
+                   bool use_escape_char,
                    char quote_char,
                    bool use_quote_char,
                    bool double_quote,
                    std::string& output, 
                    size_t& output_len);
 
-
-/**
- * Only perform double quoting escaping
- */
-void double_quote_escape(const std::string& val,
-                         std::string& output,
-                         size_t& output_len);
 } // namespace graphlab
 
 #endif

--- a/oss_src/flexible_type/string_escape.hpp
+++ b/oss_src/flexible_type/string_escape.hpp
@@ -41,6 +41,14 @@ void escape_string(const std::string& val,
                    bool double_quote,
                    std::string& output, 
                    size_t& output_len);
+
+
+/**
+ * Only perform double quoting escaping
+ */
+void double_quote_escape(const std::string& val,
+                         std::string& output,
+                         size_t& output_len);
 } // namespace graphlab
 
 #endif

--- a/oss_src/sframe/csv_line_tokenizer.cpp
+++ b/oss_src/sframe/csv_line_tokenizer.cpp
@@ -91,7 +91,9 @@ bool csv_line_tokenizer::tokenize_line(const char* str, size_t len,
                       }
                       return false;
                     },
-                     [](){}
+                     [&](){
+                       output.pop_back();
+                     }
                      );
 }
 

--- a/oss_src/sframe/csv_writer.cpp
+++ b/oss_src/sframe/csv_writer.cpp
@@ -31,7 +31,8 @@ void csv_writer::csv_print_internal(std::string& out, const flexible_type& val) 
       out += std::string(val);
       break;
     case flex_type_enum::STRING:
-      escape_string(val.get<flex_string>(), escape_char,
+      // do not print double quotes
+      escape_string(val.get<flex_string>(), escape_char, use_escape_char,
                     quote_char, true, false,
                     m_string_escape_buffer, m_string_escape_buffer_len);
       out += std::string(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
@@ -95,9 +96,8 @@ void csv_writer::csv_print(std::ostream& out,
        */
       if (quote_level == csv_quote_level::QUOTE_ALL) {
         // quote all, pass through the whole escaping sequence
-        escape_string(val.get<flex_string>(), escape_char,
-                      quote_char,
-                      true,
+        escape_string(val.get<flex_string>(), escape_char, use_escape_char,
+                      quote_char, true,
                       double_quote,
                       m_string_escape_buffer, m_string_escape_buffer_len);
         out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
@@ -133,22 +133,22 @@ void csv_writer::csv_print(std::ostream& out,
                    double_quote == true) {
           // - no delimiterization needed.
           // - we have double quote to handle quotes
-          double_quote_escape(valstr,
-                              m_string_escape_buffer, m_string_escape_buffer_len);
+          escape_string(valstr, escape_char, false,
+                        quote_char, false,
+                        double_quote,
+                        m_string_escape_buffer, m_string_escape_buffer_len);
           out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
         }  else if (quote_level == csv_quote_level::QUOTE_NONE) {
           // do not quote at all, just escape
-          escape_string(valstr, escape_char,
-                        quote_char,
-                        false,
-                        false,
+          escape_string(valstr, escape_char, use_escape_char,
+                        quote_char, false,
+                        double_quote,
                         m_string_escape_buffer, m_string_escape_buffer_len);
           out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
         } else {
           // the regular case
-          escape_string(val.get<flex_string>(), escape_char,
-                        quote_char,
-                        true,
+          escape_string(val.get<flex_string>(), escape_char, use_escape_char,
+                        quote_char, true,
                         double_quote,
                         m_string_escape_buffer, m_string_escape_buffer_len);
           out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
@@ -164,9 +164,8 @@ void csv_writer::csv_print(std::ostream& out,
       } else {
         m_complex_type_temporary.clear();
         csv_print_internal(m_complex_type_temporary, val);
-        escape_string(m_complex_type_temporary, escape_char,
-                      quote_char,
-                      true,
+        escape_string(m_complex_type_temporary, escape_char, use_escape_char,
+                      quote_char, true,
                       double_quote,
                       m_complex_type_escape_buffer,
                       m_complex_type_escape_buffer_len);

--- a/oss_src/sframe/csv_writer.cpp
+++ b/oss_src/sframe/csv_writer.cpp
@@ -31,8 +31,8 @@ void csv_writer::csv_print_internal(std::string& out, const flexible_type& val) 
       out += std::string(val);
       break;
     case flex_type_enum::STRING:
-      escape_string(val.get<flex_string>(), escape_char, 
-                    quote_char, true, false, 
+      escape_string(val.get<flex_string>(), escape_char,
+                    quote_char, true, false,
                     m_string_escape_buffer, m_string_escape_buffer_len);
       out += std::string(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
       break;
@@ -62,7 +62,11 @@ void csv_writer::csv_print_internal(std::string& out, const flexible_type& val) 
   }
 }
 
-void csv_writer::csv_print(std::ostream& out, const flexible_type& val) {
+void csv_writer::csv_print(std::ostream& out,
+                           const flexible_type& val,
+                           bool allow_empty_output) {
+  bool str_needs_delimiter = false;
+  bool str_has_quote_char = false;
   switch(val.get_type()) {
     case flex_type_enum::INTEGER:
     case flex_type_enum::FLOAT:
@@ -74,70 +78,125 @@ void csv_writer::csv_print(std::ostream& out, const flexible_type& val) {
       break;
     case flex_type_enum::DATETIME:
     case flex_type_enum::VECTOR:
-      if (quote_level != csv_quote_level::QUOTE_NONE) {
+      if (quote_level == csv_quote_level::QUOTE_NONE) {
+        out << std::string(val);
+      } else {
         // quote this field at any level higher than QUOTE_NONE
         out << quote_char << std::string(val) << quote_char;
-      } else {
-        out << std::string(val);
       }
       break;
     case flex_type_enum::STRING:
-      if (quote_level != csv_quote_level::QUOTE_NONE) {
-        escape_string(val.get<flex_string>(), escape_char, 
-                      quote_char, 
+      /*
+       * I have 4 quoting mechanisms to pick from
+       * 1) full quoting and escaping
+       * 2) no quoting but full escaping
+       * 3) no quoting but only double quote escaping
+       * 4) no quoting but no escaping
+       */
+      if (quote_level == csv_quote_level::QUOTE_ALL) {
+        // quote all, pass through the whole escaping sequence
+        escape_string(val.get<flex_string>(), escape_char,
+                      quote_char,
                       true,
                       double_quote,
                       m_string_escape_buffer, m_string_escape_buffer_len);
         out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
       } else {
-        escape_string(val.get<flex_string>(), escape_char, 
-                      quote_char, 
-                      false,
-                      false,
-                      m_string_escape_buffer, m_string_escape_buffer_len);
-        out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
+        // not quote all. we can pick from a bunch of heuristics
+        // to get minimal quoting
+        const flex_string& valstr = val.get<flex_string>();
+        // if there is a special character, or escape character or
+        // line terminater in the string, we need full escaping
+        //
+        // if there is a quote char in the string, we need  at least
+        // double quote escaping
+        for (const char c : valstr) {
+          if (str_needs_delimiter == false &&
+              (c == '\t' || c == '\r' || c== '\n' || c == '\b' || c == escape_char ||
+               (!line_terminator.empty() && c == line_terminator[0]) ||
+               (!delimiter.empty() && c == delimiter[0]))) {
+            str_needs_delimiter = true;
+          }
+          if (str_has_quote_char == false && c == quote_char) {
+            str_has_quote_char = true;
+          }
+          if (str_has_quote_char && str_needs_delimiter) break;
+        }
+
+        if (allow_empty_output == false && valstr.length() == 0) {
+          out << quote_char << quote_char;
+        } else if (str_needs_delimiter == false && str_has_quote_char == false) {
+          // - no delimiterization needed.
+          out.write(valstr.c_str(), valstr.length());
+        } else if (str_needs_delimiter == false &&
+                   str_has_quote_char == true &&
+                   double_quote == true) {
+          // - no delimiterization needed.
+          // - we have double quote to handle quotes
+          double_quote_escape(valstr,
+                              m_string_escape_buffer, m_string_escape_buffer_len);
+          out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
+        }  else if (quote_level == csv_quote_level::QUOTE_NONE) {
+          // do not quote at all, just escape
+          escape_string(valstr, escape_char,
+                        quote_char,
+                        false,
+                        false,
+                        m_string_escape_buffer, m_string_escape_buffer_len);
+          out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
+        } else {
+          // the regular case
+          escape_string(val.get<flex_string>(), escape_char,
+                        quote_char,
+                        true,
+                        double_quote,
+                        m_string_escape_buffer, m_string_escape_buffer_len);
+          out.write(m_string_escape_buffer.c_str(), m_string_escape_buffer_len);
+        }
       }
       break;
     case flex_type_enum::LIST:
     case flex_type_enum::DICT:
-      if (quote_level != csv_quote_level::QUOTE_NONE) {
-        m_complex_type_temporary.clear();
-        csv_print_internal(m_complex_type_temporary, val);
-        escape_string(m_complex_type_temporary, escape_char, 
-                      quote_char, 
-                      true,
-                      double_quote,
-                      m_complex_type_escape_buffer, 
-                      m_complex_type_escape_buffer_len);
-        out.write(m_complex_type_escape_buffer.c_str(), m_complex_type_escape_buffer_len);
-      } else {
+      if (quote_level == csv_quote_level::QUOTE_NONE) {
         m_complex_type_temporary.clear();
         csv_print_internal(m_complex_type_temporary, val);
         out.write(m_complex_type_temporary.c_str(), m_complex_type_temporary.length());
+      } else {
+        m_complex_type_temporary.clear();
+        csv_print_internal(m_complex_type_temporary, val);
+        escape_string(m_complex_type_temporary, escape_char,
+                      quote_char,
+                      true,
+                      double_quote,
+                      m_complex_type_escape_buffer,
+                      m_complex_type_escape_buffer_len);
+        out.write(m_complex_type_escape_buffer.c_str(), m_complex_type_escape_buffer_len);
       }
       break;
     case flex_type_enum::UNDEFINED:
-      if (quote_level != csv_quote_level::QUOTE_ALL) {
-        out.write(na_value.c_str(), na_value.length());
-      } else {
+      if (quote_level == csv_quote_level::QUOTE_ALL) {
         out << quote_char << na_value << quote_char;
+      } else {
+        out.write(na_value.c_str(), na_value.length());
       }
       break;
     default:
-      if (quote_level != csv_quote_level::QUOTE_NONE) {
+      if (quote_level == csv_quote_level::QUOTE_NONE) {
+        out << std::string(val);
+      } else {
         // quote this field at any level higher than QUOTE_NONE
         out << quote_char << std::string(val) << quote_char;
-      } else {
-        out << std::string(val);
       }
       break;
   }
 }
 
-void csv_writer::write(std::ostream& out, 
+void csv_writer::write(std::ostream& out,
                        const std::vector<flexible_type>& row) {
+  // if row size is 1, we cannot allow empty output
+  bool allow_empty_output = row.size() > 1;
   for (size_t i = 0;i < row.size(); ++i) {
-    csv_print(out, row[i]);
+    csv_print(out, row[i], row.size() > 1);
     // put a delimiter after every element except for the last element.
     if (i + 1 < row.size()) out << delimiter;
   }

--- a/oss_src/sframe/csv_writer.hpp
+++ b/oss_src/sframe/csv_writer.hpp
@@ -31,16 +31,21 @@ class csv_writer {
   std::string delimiter = ",";
 
   /**
-   * The character to use to identify the beginning of a C escape sequence 
+   * The character to use to identify the beginning of a C escape sequence
    * (Defualt '\'). i.e. "\n" will be converted to the '\n' character, "\\"
-   * will be converted to "\", etc. Note that only the single character 
+   * will be converted to "\", etc. Note that only the single character
    * escapes are converted. unicode (\Unnnn), octal (\nnn), hexadecimal (\xnn)
    * are not interpreted.
    */
   char escape_char = '\\';
 
   /**
-   * If set to true, pairs of quote characters in a quoted string 
+   * If true, escape characters will not be used at all.
+   */
+  bool use_escape_char = true;
+
+  /**
+   * If set to true, pairs of quote characters in a quoted string
    * are interpreted as a single quote (Default false).
    * For instance, if set to true, the 2nd field of the 2nd line is read as
    * \b "hello "world""
@@ -49,7 +54,7 @@ class csv_writer {
    * 123, "hello ""world"""
    * \endverbatim
    */
-  bool double_quote = true; 
+  bool double_quote = true;
 
   /**
    * The quote character to use (Default '\"')
@@ -84,20 +89,33 @@ class csv_writer {
   void write_verbatim(std::ostream& out, const std::vector<std::string>& row);
 
   /**
-   * Writes an array of values as a row, making the appropriate formatting 
+   * Writes an array of values as a row, making the appropriate formatting
    * changes. Not safe to use in parallel.
    */
   void write(std::ostream& out, const std::vector<flexible_type>& row);
-  
+
   /**
-   * Converts one value to a string
+   * Converts one value to a string.
+   * \param out The stream to write to
+   * \param val The value of emit
+   * \param allow_empty_output This parameter is a little tricky to interpret.
+   *  If this flag is set to true (default), some inputs may result in
+   *  completely empty outputs.  (For instance empty string, or missing value
+   *  where na_value is the empty string). This can cause issues in some
+   *  situations. For instance, in a csv file with only a single columns, some
+   *  parsers may skip empty lines. If this flag is set to false, the complete
+   *  empty output will never be emitted and instead
+   *  out << quote_char << quote_char
+   *  will be generated.
    */
-  void csv_print(std::ostream& out, const flexible_type& val);
- 
+  void csv_print(std::ostream& out,
+                 const flexible_type& val,
+                 bool allow_empty_output=true);
+
  private:
 
   /**
-   * Converts one value, appending it to a string. 
+   * Converts one value, appending it to a string.
    * minimal quoting is performed: only strings are quoted.
    * This is used for recursive prints (ex: printing a list)
    */
@@ -105,28 +123,28 @@ class csv_writer {
 
   /*
    * These are basically some optimizations to csv_print / csv_print_internal
-   * to avoid allocating additional strings everytime. We just 
+   * to avoid allocating additional strings everytime. We just
    * repeatedly make use of the same set of buffers.
    * This does mean that csv_print is *not* thread safe. But that's alright.
-   */ 
+   */
 
   /** The buffer used by csv_print to handle additional quoting required.
-   * Specifically, csv_print calls csv_print_internal on some cases 
+   * Specifically, csv_print calls csv_print_internal on some cases
    * (like dictionary) into this buffer. Then calls escape_string on this
    * buffer to generate a dictionary in string form.
    */
-  std::string m_complex_type_temporary; 
-  std::string m_complex_type_escape_buffer; 
-  size_t m_complex_type_escape_buffer_len = 0; 
+  std::string m_complex_type_temporary;
+  std::string m_complex_type_escape_buffer;
+  size_t m_complex_type_escape_buffer_len = 0;
 
   /**
-   * Temporary storage used by csv_print, and csv_print_internal to escape 
+   * Temporary storage used by csv_print, and csv_print_internal to escape
    * flexible_types containing strings.
    */
-  std::string m_string_escape_buffer; 
-  size_t m_string_escape_buffer_len = 0; 
+  std::string m_string_escape_buffer;
+  size_t m_string_escape_buffer_len = 0;
 };
-  
+
 
 } // namespace graphlab
 #endif

--- a/oss_src/sframe/csv_writer.hpp
+++ b/oss_src/sframe/csv_writer.hpp
@@ -40,7 +40,8 @@ class csv_writer {
   char escape_char = '\\';
 
   /**
-   * If true, escape characters will not be used at all.
+   * If true, escape characters will not be used at all. Note that enabling
+   * this may result in non-parseable CSVs.
    */
   bool use_escape_char = true;
 

--- a/oss_src/sframe/parallel_csv_parser.cpp
+++ b/oss_src/sframe/parallel_csv_parser.cpp
@@ -992,6 +992,22 @@ std::map<std::string, std::shared_ptr<sarray<flexible_type>>> parse_csvs_to_sfra
   
   for (auto p : file_and_status) {
     if (p.second == file_status::REGULAR_FILE) {
+      // throw away empty files
+      try {
+        general_ifstream fin(p.first);
+        if (fin.file_size() == 0) {
+          logstream(LOG_INFO) << "Skipping file "
+                              << sanitize_url(p.first)
+                              << " because it appears to be empty"
+                              << std::endl;
+          continue;
+        }
+      } catch (...) {
+          logstream(LOG_INFO) << "Can't get size of file "
+                              << sanitize_url(p.first)
+                              << std::endl;
+      }
+
       logstream(LOG_INFO) << "Adding CSV file " 
                           << sanitize_url(p.first)
                           << " to list of files to parse"

--- a/oss_src/unity/lib/unity_sframe.cpp
+++ b/oss_src/unity/lib/unity_sframe.cpp
@@ -889,6 +889,7 @@ void unity_sframe::save_as_csv(const std::string& url,
   // first the defaults
   writer.delimiter = ",";
   writer.escape_char = '\\';
+  writer.use_escape_char = true;
   writer.double_quote = true;
   writer.quote_char = '\"';
   writer.quote_level = csv_writer::csv_quote_level::QUOTE_NONNUMERIC;
@@ -907,6 +908,7 @@ void unity_sframe::save_as_csv(const std::string& url,
   if (writing_config["escape_char"].get_type() == flex_type_enum::STRING) {
     std::string tmp = (flex_string)writing_config["escape_char"];
     if (tmp.length() > 0) writer.escape_char = tmp[0];
+    else writer.use_escape_char = false;
   }
   if (writing_config.count("double_quote")) {
     writer.double_quote = !writing_config["double_quote"].is_zero();

--- a/oss_src/unity/python/sframe/data_structures/sframe.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe.py
@@ -1197,9 +1197,9 @@ class SFrame(object):
             A string or list of strings to be interpreted as missing values.
 
         line_terminator : str, optional
-            A string to be interpreted as the line terminator. Defaults to "\n"
+            A string to be interpreted as the line terminator. Defaults to "\\n"
             which will also correctly match Mac, Linux and Windows line endings
-            ("\r", "\n" and "\r\n" respectively)
+            ("\\r", "\\n" and "\\r\\n" respectively)
 
         usecols : list of str, optional
             A subset of column names to output. If unspecified (default),
@@ -1351,7 +1351,7 @@ class SFrame(object):
         line_terminator : str, optional
             A string to be interpreted as the line terminator. Defaults to "\n"
             which will also correctly match Mac, Linux and Windows line endings
-            ("\r", "\n" and "\r\n" respectively)
+            ("\\r", "\\n" and "\\r\\n" respectively)
 
         usecols : list of str, optional
             A subset of column names to output. If unspecified (default),

--- a/oss_test/sframe/sframe_csv_test.cxx
+++ b/oss_test/sframe/sframe_csv_test.cxx
@@ -563,6 +563,22 @@ csv_test multiline_json() {
   return ret;
 }
 
+csv_test tab_delimited_csv_with_list() {
+  csv_test ret;
+  std::stringstream strm;
+  strm << "xxx\t[1,2,3]\t[1,2,3]\n";
+  ret.file = strm.str();
+  ret.tokenizer.delimiter = "\t";
+  ret.header = false;
+
+  ret.values.push_back({"xxx", flex_list{1,2,3}, flex_list{1,2,3}});
+
+  ret.types = {{"X1", flex_type_enum::STRING},
+               {"X2", flex_type_enum::LIST},
+               {"X3", flex_type_enum::LIST}};
+  return ret;
+}
+
 struct test_equality_visitor {
   template <typename T, typename U>
   void operator()(T& t, const U& u) const { TS_FAIL("type mismatch"); }
@@ -770,6 +786,7 @@ class sframe_test : public CxxTest::TestSuite {
      evaluate(non_escaped_parsing());
      evaluate(single_string_column());
      evaluate(test_missing_tab_values());
+     evaluate(tab_delimited_csv_with_list());
    }
 
 

--- a/oss_test/sframe/sframe_csv_test.cxx
+++ b/oss_test/sframe/sframe_csv_test.cxx
@@ -107,7 +107,7 @@ csv_test basic_comments_and_skips(std::string dlm=",", std::string line_ending="
 std::string default_escape_string(std::string s) {
   std::string out;
   size_t outputlength;
-  escape_string(s, '\\','\"',true, false, out, outputlength);
+  escape_string(s, '\\',true,'\"',true, false, out, outputlength);
   out.resize(outputlength);
   return out;
 }


### PR DESCRIPTION
 - Improved consistency of export_csv. Make it respect quoting options better, and support the complete disabling of the escape character. (#143)
 - Allowed read_csv with glob expressions to skip empty files
 - Fixed an interesting parsing error (#145)