### PR TITLE
Flex types always converted correctly in cy_variant

### DIFF
--- a/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
@@ -1270,7 +1270,7 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
 
     # These are optimized by the cython compiler into a big switch statement.
     if tr_code == FT_INT_TYPE:
-        ret.set_int(<long>v)
+        ret.set_int(<flex_int>v)
         return ret
     elif tr_code == FT_FLOAT_TYPE:
         ret.set_double(<double>v)


### PR DESCRIPTION
Updated the logic in cy_variant.pyx to ensure that flexible types are
converted correctly.  Before, some types that should have been treated
as flexible types were converted to variant types instead.  This PR
ensures that such types are indeed converted correctly.  Tests included.