### PR TITLE
Fix read/write hdfs

### DIFF
--- a/oss_src/fileio/libhdfs_shim.cpp
+++ b/oss_src/fileio/libhdfs_shim.cpp
@@ -384,6 +384,26 @@ extern  "C" {
     search_prefixes = {""};
     search_suffixes = {""};
     file_name = "libjvm.dylib";
+
+    // Run /usr/libexec/java_home to get the libjvm location
+    std::string libjvm_location = "";
+    std::string java_home_cmd = "/usr/libexec/java_home";
+    try {
+      process p;
+      p.popen(java_home_cmd,
+              std::vector<std::string>(),
+              STDOUT_FILENO);
+      libjvm_location = p.read_from_child();
+      logstream(LOG_INFO) << "Obtain JAVA_HOME from " << java_home_cmd << ": " << libjvm_location << std::endl;
+    } catch (...) {
+      logstream(LOG_WARNING) << "Error running " << java_home_cmd << std::endl;
+      libjvm_location = "";
+    }
+    if (!libjvm_location.empty()) {
+      // Make this location to be searched first `/usr/libexec/java_home`/jre/lib/server/libjvm.dylib
+      search_prefixes.insert(search_prefixes.begin(), libjvm_location);
+      search_suffixes.insert(search_suffixes.begin(), "/jre/lib/server");
+    }
 #else
     search_prefixes = {
       "/usr/lib/jvm/default-java",               // ubuntu / debian distros

--- a/oss_src/fileio/libhdfs_shim.cpp
+++ b/oss_src/fileio/libhdfs_shim.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem.hpp>
 #include <parallel/execute_task_in_native_thread.hpp>
 #include <type_traits>
+#include <process/process.hpp>
 #ifdef HAS_HADOOP
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -389,7 +390,7 @@ extern  "C" {
     std::string libjvm_location = "";
     std::string java_home_cmd = "/usr/libexec/java_home";
     try {
-      process p;
+      graphlab::process p;
       p.popen(java_home_cmd,
               std::vector<std::string>(),
               STDOUT_FILENO);

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -202,8 +202,9 @@ def _make_internal_url(url):
     is_local = False
     if protocol in ['http', 'https']:
         pass
-    elif protocol == 'hdfs' and not sys_util.get_hadoop_class_path():
-        raise ValueError("HDFS URL is not supported because Hadoop not found. Please make hadoop available from PATH or set the environment variable HADOOP_HOME and try again.")
+    elif protocol == 'hdfs':
+        if not sys_util.get_hadoop_class_path():
+            raise ValueError("HDFS URL is not supported because Hadoop not found. Please make hadoop available from PATH or set the environment variable HADOOP_HOME and try again.")
     elif protocol == 's3':
         return _try_inject_s3_credentials(url)
     elif protocol == '' or (protocol == 'local' or protocol == 'remote'):


### PR DESCRIPTION
Use more robust libjvm.dylib for libhdfs on OS X

Inject `/usr/libexec/java_home`/jre/lib/server/libjvm.dylib to
be the first search location for libjvm. This is the most robust
way to get the latest system libjvm.

Also fix another bug in hdfs protocol validation

This should resolve issue #159