### PR TITLE
Fix several bugs in the DBAPI2 support

### DIFF
--- a/oss_src/unity/python/sframe/data_structures/sframe_builder.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe_builder.py
@@ -152,6 +152,13 @@ class SFrameBuilder(object):
         tmp_list = []
         block_pos = 0
 
+        # Avoid copy in cases that we are passed materialized data that is
+        # smaller than our block size
+        if hasattr(data, '__len__'):
+            if len(data) <= self._block_size:
+                self._builder.append_multiple(data, segment)
+                return
+
         for i in data:
             tmp_list.append(i)
             if len(tmp_list) >= self._block_size:

--- a/oss_src/unity/python/sframe/test/dbapi2_mock/__init__.py
+++ b/oss_src/unity/python/sframe/test/dbapi2_mock/__init__.py
@@ -17,3 +17,4 @@ class dbapi2_mock(object):
         self.DATETIME = 43
         self.NUMBER = 44
         self.ROWID = 45
+        self.Error = StandardError


### PR DESCRIPTION
This patch gets my scenario tests (which I have to commit AFTER this is merged I think) to pass on sqlite3, psycopg2, and MySQLdb.

Issues addressed:

- Sometimes to_sql rearranged the data in the columns. This not only was
  wrong, but caused schema type errors in some instances.

- Account for psycopg2's need to rollback if any cursor anywhere
  encounters an exception.

- Account for MySQLdb's iterator behavior not matching sqlite3 or
  psycopg2, by not using an iterator at all in from_sql..instead
  switching to fetchone() and fetchmany(), which are actually in the
  mandatory DBAPI2 standard (the iterator is optional). As a result,
  added the "cursor_arraysize" parameter to from_sql to read data in
  chunks from the DB.

- Account for sqlite3's lack of strong types by not failing if the
  required type constants aren't defined...rather letting the type
  inference fall to str if the constants aren't defined.

- Add to the ability of _assert_sframe_equal to assert that float
  columns are approximately equal.