### PR TITLE
Add "use_exact_column_names" option to to_sql.

### DIFF
--- a/oss_src/unity/python/sframe/test/test_sframe.py
+++ b/oss_src/unity/python/sframe/test/test_sframe.py
@@ -3142,7 +3142,7 @@ class SFrameTest(unittest.TestCase):
     def test_to_sql(self, mock_conn, mock_cursor):
         conn = mock_conn('example.db')
         curs = mock_cursor()
-        insert_stmt = "INSERT INTO ins_test VALUES ({0},{1},{2},{3},{4},{5},{6})"
+        insert_stmt = "INSERT INTO ins_test (X1,X2,X3,X4,X5,X6,X7) VALUES ({0},{1},{2},{3},{4},{5},{6})"
         num_cols = len(self.sf_all_types.column_names())
         test_cases = [
             ('qmark',insert_stmt.format(*['?' for i in range(num_cols)])),


### PR DESCRIPTION
This changes the default behavior of to_sql. to_sql will now submit data
expecting the column names in the SFrame to match up exactly to the
column names of the table it is inserting into. If this option is set to
False, then the old behavior will take over, where the data values in
the SFrame are simply submitted in order to the table without care of
what columns are in the table.

This also adds metrics and a message about the beta status of this API.