### PR TITLE
Restored incremental printout in IPython notebook

### DIFF
--- a/oss_src/unity/python/sframe/cython/cy_ipc.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pxd
@@ -25,3 +25,7 @@ cdef class PyCommClient:
     cdef comm_client *thisptr 
     cpdef stop(self)
     cpdef start(self)
+
+cdef void print_status(string status_string) nogil
+
+cpdef get_print_status_function_pointer()

--- a/oss_src/unity/python/sframe/cython/cy_ipc.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_ipc.pyx
@@ -10,7 +10,6 @@ from libcpp.string cimport string
 from libc.stdio cimport printf
 from .python_printer_callback import print_callback
 
-
 cdef class PyCommClient:
 
     def __cinit__(self):
@@ -33,3 +32,13 @@ def make_comm_client_from_existing_ptr(size_t client_ptr):
     ret = PyCommClient()
     ret.thisptr = <comm_client*>(client_ptr)
     return ret
+
+
+cdef void print_status(string status_string) nogil:
+    with gil:
+        status_string = status_string.rstrip()
+        print_callback(status_string)
+
+ctypedef void* void_p
+cpdef get_print_status_function_pointer():
+    return <size_t>(<void_p>(print_status))

--- a/oss_src/unity/python/sframe/cython/python_printer_callback.py
+++ b/oss_src/unity/python/sframe/cython/python_printer_callback.py
@@ -27,7 +27,7 @@ def print_callback(val):
         # I have to intrude rather deep into IPython to make it behave
         if have_ipython:
             if InteractiveShell.initialized():
-                IPython.display.publish_display_data('graphlab.callback', {'text/plain':val,'text/html':'<pre>' + val + '</pre>'})
+                IPython.display.publish_display_data({'text/plain':val,'text/html':'<pre>' + val + '</pre>'})
                 success = True
     except:
         pass

--- a/oss_src/unity/server/unity_server.cpp
+++ b/oss_src/unity/server/unity_server.cpp
@@ -142,5 +142,16 @@ void unity_server::set_log_progress(bool enable) {
   }
 }
 
+void unity_server::set_log_progress_callback(void (*callback)(std::string)) {
+  if (callback == nullptr) {
+    global_logger().add_observer(LOG_PROGRESS, NULL);
+  } else {
+    global_logger().add_observer(
+        LOG_PROGRESS,
+        [=](int lineloglevel, const char* buf, size_t len){
+          callback(std::string(buf, len));
+        });
+  }
+}
 
 } // end of graphlab

--- a/oss_src/unity/server/unity_server.hpp
+++ b/oss_src/unity/server/unity_server.hpp
@@ -42,6 +42,8 @@ class unity_server {
    */
   static void set_log_progress(bool enable);
 
+  static void set_log_progress_callback(void (*callback)(std::string));
+
   inline cppipc::comm_server* get_comm_server() { return server; }
 
   inline std::string get_comm_server_address() { return options.server_address; }

--- a/oss_src/unity/server/unity_server.hpp
+++ b/oss_src/unity/server/unity_server.hpp
@@ -8,6 +8,8 @@
 #ifndef SFRAME_UNITY_SERVER_HPP
 #define SFRAME_UNITY_SERVER_HPP
 
+#include <parallel/pthread_tools.hpp>
+#include <util/blocking_queue.hpp>
 #include "unity_server_options.hpp"
 #include "unity_server_init.hpp"
 
@@ -22,6 +24,8 @@ class toolkit_class_registry;
 
 class unity_server {
  public:
+  typedef void(*progress_callback_type)(std::string);
+
   /**
    * Constructor
    */
@@ -40,9 +44,9 @@ class unity_server {
   /**
    * Enable or disable log progress stream.
    */
-  static void set_log_progress(bool enable);
+  void set_log_progress(bool enable);
 
-  static void set_log_progress_callback(void (*callback)(std::string));
+  void set_log_progress_callback(progress_callback_type callback);
 
   inline cppipc::comm_server* get_comm_server() { return server; }
 
@@ -61,6 +65,12 @@ class unity_server {
   cppipc::comm_server* server;
   toolkit_function_registry* toolkit_functions;
   toolkit_class_registry* toolkit_classes;
+
+ private:
+  volatile progress_callback_type log_progress_callback = nullptr;
+  graphlab::thread log_thread;
+  blocking_queue<std::string> log_queue;
+
 }; // end of class usenity_server
 } // end of namespace graphlab
 

--- a/oss_src/unity/server/unity_server_capi.cpp
+++ b/oss_src/unity/server/unity_server_capi.cpp
@@ -101,5 +101,9 @@ EXPORT void stop_server() {
 EXPORT void set_log_progress(bool enable) {
   graphlab::unity_server::set_log_progress(enable);
 }
+
+EXPORT void set_log_progress_callback(void* callback) {
+  graphlab::unity_server::set_log_progress_callback(reinterpret_cast<void(*)(std::string)>(callback));
+}
 }
  // end of extern "C"

--- a/oss_src/unity/server/unity_server_capi.cpp
+++ b/oss_src/unity/server/unity_server_capi.cpp
@@ -99,11 +99,15 @@ EXPORT void stop_server() {
  * Enable or disable log progress stream.
  */
 EXPORT void set_log_progress(bool enable) {
-  graphlab::unity_server::set_log_progress(enable);
+  if (graphlab::SERVER) {
+    graphlab::SERVER->set_log_progress(enable);
+  }
 }
 
 EXPORT void set_log_progress_callback(void* callback) {
-  graphlab::unity_server::set_log_progress_callback(reinterpret_cast<void(*)(std::string)>(callback));
+  if (graphlab::SERVER) {
+    graphlab::SERVER->set_log_progress_callback(reinterpret_cast<void(*)(std::string)>(callback));
+  }
 }
 }
  // end of extern "C"


### PR DESCRIPTION
Progress printing to ipython/jupyter notebook is broken. as in progress messages now completely don't make it to ipython/jupyter notebook. This is extraordinarily annoying. The issue is that with removal of unity_server, logprogress now goes straight to stdout. However, ipython/jupyter notebook does not capture stdout. 

One solution is to return to the old zeromq queueing + callback mechanism. But that is not desirable since we are trying to remove zeromq. The alternate solution implemented here is to use the callback mechanism to push a cython function pointer all the way to the progress printer.