### PR TITLE
Fixed path issue in test_io.

### DIFF
--- a/oss_src/unity/python/sframe/test/test_io.py
+++ b/oss_src/unity/python/sframe/test/test_io.py
@@ -9,7 +9,7 @@ import commands
 import json
 import logging
 import os
-import re
+import fnmatch
 import tempfile
 import unittest
 import pandas
@@ -37,9 +37,9 @@ def _test_save_load_object_helper(testcase, obj, path):
         Remove the saved file from temp directory.
         """
         tempdir = tempfile.gettempdir()
-        pattern = path + ".*"
+        pattern = path + "*"
         for f in os.listdir(tempdir):
-            if re.search(pattern, f):
+            if fnmatch.fnmatch(pattern, f):
                 os.remove(os.path.join(tempdir, f))
 
     if isinstance(obj, SGraph):


### PR DESCRIPTION
re.match on path names is way to liberal with paths, and fails with a compilation error on unicode paths, which can sometimes be returned (it seems) by os.tempfile on windows.  Use fnmatch instead to do linux glob style matching. 