### PR TITLE
Fix incorrect cache eviction

### DIFF
--- a/oss_src/fileio/union_fstream.cpp
+++ b/oss_src/fileio/union_fstream.cpp
@@ -68,6 +68,7 @@ union_fstream::union_fstream(std::string url,
       input_stream = (*cachestream)->get_underlying_stream();
       if (input_stream == nullptr) input_stream = cachestream;
       m_file_size = (*cachestream)->file_size();
+      original_input_stream_handle = std::static_pointer_cast<std::istream>(cachestream);
     }
   } else if (boost::starts_with(url, "s3://")) {
     // the S3 file type currently works by download/uploading a local file
@@ -80,6 +81,7 @@ union_fstream::union_fstream(std::string url,
       input_stream = (*s3stream)->get_underlying_stream();
       if (input_stream == nullptr) input_stream = s3stream;
       m_file_size = (*s3stream)->file_size();
+      original_input_stream_handle = std::static_pointer_cast<std::istream>(s3stream);
     }
   } else {
     // must be local file

--- a/oss_src/fileio/union_fstream.hpp
+++ b/oss_src/fileio/union_fstream.hpp
@@ -66,6 +66,9 @@ class union_fstream {
 
   std::shared_ptr<std::istream> input_stream;
   std::shared_ptr<std::ostream> output_stream;
+
+  // Hold the input stream from cache or s3 stream.
+  std::shared_ptr<std::istream> original_input_stream_handle;
 };
 
 } // namespace graphlab


### PR DESCRIPTION
Fix the bug where the fileio cache layer allows read of a
evicted cache_block.

The cache eviction relies on the evicting thread being the only
holder of the cache_block. However, the union_fstream took an optimization
to directly grab the underlying input stream of a cache_stream,
thus giving up the cahce_block handle, allowing eviction to happen.

The fix is to remember the orignal cachestream which holds reference to
the cache_block. This prevents the block from being evicted.