### PR TITLE
Critical Bug fix to logical filter

### DIFF
--- a/oss_src/sframe_query_engine/operators/operator_properties.cpp
+++ b/oss_src/sframe_query_engine/operators/operator_properties.cpp
@@ -343,6 +343,15 @@ struct length_info {
   void* source_node; // if length is unknown this contains a unique descriptor
                      // of the length
 };
+/*
+ * This function returns for a given node, a "length_info" attribute.
+ *  - length_info.source_length: The length of the node if known. -1 if not known
+ *  - source_node: If the length is unkonwn, this contains a unique descriptor
+ *                 of the length. i.e. if two differet nodes have the same
+ *                 descriptor, they have the same length. But if they have
+ *                 different descriptors, there is nothing we can say about
+ *                 their lengths.
+ */
 static length_info propagate_length(
     const pnode_ptr& n, std::map<pnode_ptr, length_info>& visited) {
   auto it = visited.find(n);
@@ -373,7 +382,10 @@ std::pair<bool, bool> prove_equal_length(const std::shared_ptr<planner_node>& a,
   if (la.source_length != -1 &&  lb.source_length != -1) {
     return {true, la.source_length == lb.source_length};
   } else if (la.source_length == -1 && lb.source_length == -1) {
-    return {true, la.source_node == lb.source_node};
+    // if the source id is the same, we have proved they have
+    // the same length. Otherwise, we can't really say if they are the same
+    // length. (could be two different sources of the same size)
+    return {la.source_node == lb.source_node, la.source_node == lb.source_node};
   } else {
     return {false, false};
   }

--- a/oss_src/unity/python/sframe/test/test_sframe.py
+++ b/oss_src/unity/python/sframe/test/test_sframe.py
@@ -2924,6 +2924,23 @@ class SFrameTest(unittest.TestCase):
         self.assertFalse(sf.__is_materialized__())
         self.assertFalse(sf.__has_size__())
 
+    def test_lazy_logical_filter_sarray(self):
+        g=SArray(range(10000))
+        g2=SArray(range(10000))
+        a=g[g>10]
+        a2=g2[g>10]
+        z=a[a2>20]
+        self.assertEqual(len(z), 9979)
+
+    def test_lazy_logical_filter_sframe(self):
+        g=SFrame({'a':range(10000)})
+        g2=SFrame({'a':range(10000)})
+        a=g[g['a']>10]
+        a2=g2[g['a']>10]
+        z=a[a2['a']>20]
+        self.assertEqual(len(z), 9979)
+
+
     def test_sframe_to_rdd(self):
         if not HAS_PYSPARK:
             print("Did not run Pyspark unit tests!")


### PR DESCRIPTION
The following code fails due to the inability to prove that a and a2 have the
same length when performing the logical filter. The code is supposed to
selectively materialize the filter so that length can be proven. However,
due to a bug in the prove_equal_length method, that was not done.

```
g=SArray(range(10000))
g2=SArray(range(10000))
a=g[g>10]
a2=g2[g>10]
a[a2>20] # Fail here
```