### PR TITLE
Some regression fixing bug fixes

### DIFF
--- a/configure
+++ b/configure
@@ -274,6 +274,7 @@ fi
 
 mkdir -p doc
 
+export LD_LIBRARY_PATH=${PWD}/deps/local/lib:${PWD}/deps/local/lib64:$PWD
 echo "======================= BUILD CONFIGURATION ========================"
 echo "System Information: " 
 uname -v
@@ -314,7 +315,6 @@ if [[ $OSTYPE == msys ]]; then
 fi
 ## ============================================================================
 # Run Cmake
-export LD_LIBRARY_PATH=${PWD}/deps/local/lib:${PWD}/deps/local/lib64:$PWD
 
 
 

--- a/configure
+++ b/configure
@@ -63,7 +63,9 @@ function print_help {
   echo "                          or a URL to a toolchain. If toolchain is"
   echo "                          \"default\", a default one is selected"
   echo
-  echo "  --no_cuda               Selects a Cuda-less toolchain if available"
+  echo "  --cuda                  Selects a Cuda toolchain if available"
+  echo
+  echo "  --no_cuda               Selects a Cuda-less toolchain if available (default)"
   echo 
   echo "  -D var=value            Specify CFLAGS definitions to be passed on to cmake."
   echo 
@@ -153,11 +155,12 @@ cleanup_option=0
 cleanup_if_invalid_option=0
 toolchain=""
 default_yes=0
-no_cuda=0
+no_cuda=1
 # Parse command line configure flags ------------------------------------------
 while [ $# -gt 0 ]
   do case $1 in
     --toolchain=*)          toolchain=${1##--toolchain=} ;;
+    --cuda)                 no_cuda=0;;
     --no_cuda)              no_cuda=1;;
     --cleanup)              cleanup_option=1;;
     --cleanup_if_invalid)   cleanup_if_invalid_option=1;;

--- a/oss_local_scripts/make_egg.sh
+++ b/oss_local_scripts/make_egg.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 WORKSPACE=${SCRIPT_DIR}/..
 ABS_WORKSPACE=`dirname $SCRIPT_DIR`
 build_type="release"
-export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
+#export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
 
 print_help() {
   echo "Builds the release branch and produce an egg to the targets directory "

--- a/oss_local_scripts/make_egg.sh
+++ b/oss_local_scripts/make_egg.sh
@@ -99,7 +99,7 @@ fi
 
 push_ld_library_path() {
   OLD_LIBRARY_PATH=$LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=${WORKSPACE}/deps/local/lib:${WORKSPACE}/deps/local/lib64:$LD_LIBRARY_PATH
 }
 
 pop_ld_library_path() {

--- a/oss_local_scripts/make_egg.sh
+++ b/oss_local_scripts/make_egg.sh
@@ -11,7 +11,6 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 WORKSPACE=${SCRIPT_DIR}/..
 ABS_WORKSPACE=`dirname $SCRIPT_DIR`
 build_type="release"
-#export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
 
 print_help() {
   echo "Builds the release branch and produce an egg to the targets directory "
@@ -98,9 +97,18 @@ if [[ $OSTYPE == msys ]]; then
   unset PYTHONHOME
 fi
 
+push_ld_library_path() {
+  OLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
+}
+
+pop_ld_library_path() {
+  export LD_LIBRARY_PATH=$OLD_LIBRARY_PATH
+}
 
 ### Build the source with version number ###
 build_source() {
+
   echo -e "\n\n\n================= Build ${BUILD_NUMBER} ================\n\n\n"
 
   # Configure
@@ -113,6 +121,8 @@ build_source() {
       ./configure ${toolchain}
   fi
 
+  push_ld_library_path
+
   # Make clean
   cd ${WORKSPACE}/${build_type}/oss_src/unity/python
   make oss_clean_python
@@ -124,7 +134,9 @@ build_source() {
       cd ${WORKSPACE}/${build_type}/oss_test
       make -j${NUM_PROCS}
   fi
+  pop_ld_library_path
   echo -e "\n\n================= Done Build Source ================\n\n"
+
 }
 
 # Run all unit test
@@ -269,8 +281,10 @@ generate_docs() {
   SPHINXBUILD=${WORKSPACE}/$PYTHON_SCRIPTS/sphinx-build
 
   cd ${WORKSPACE}/oss_src/unity/python/doc
+  push_ld_library_path
   make clean SPHINXBUILD=${SPHINXBUILD}
   make html SPHINXBUILD=${SPHINXBUILD}
+  pop_ld_library_path
   tar -czvf ${TARGET_DIR}/sframe_python_sphinx_docs.${archive_file_ext} *
 }
 

--- a/oss_local_scripts/python_env.sh
+++ b/oss_local_scripts/python_env.sh
@@ -36,7 +36,7 @@ fi
 # Graphlab project root
 ROOT_DIR=$SCRIPT_DIR/..
 
-export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
+#export LD_LIBRARY_PATH=${ROOT_DIR}/deps/local/lib:${ROOT_DIR}/deps/local/lib64:$LD_LIBRARY_PATH
 PYTHON_SCRIPTS=deps/conda/bin
 if [[ $OSTYPE == msys ]]; then
   PYTHON_SCRIPTS=deps/conda/bin/Scripts

--- a/oss_local_scripts/run_python_test.sh
+++ b/oss_local_scripts/run_python_test.sh
@@ -14,15 +14,27 @@ if [[ -z $1 ]]; then
 fi
 BUILD_TYPE=$1
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-cd ${SCRIPT_DIR}/..
+WORKSPACE=${SCRIPT_DIR}/..
+cd ${WORKSPACE}
 source oss_local_scripts/python_env.sh $BUILD_TYPE
 
 # Make nosetest prints unity server log on exception
 export DATO_VERBOSE=1
 
+push_ld_library_path() {
+  OLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=${WORKSPACE}/deps/local/lib:${WORKSPACE}/deps/local/lib64:$LD_LIBRARY_PATH
+}
+
+pop_ld_library_path() {
+  export LD_LIBRARY_PATH=$OLD_LIBRARY_PATH
+}
+
+push_ld_library_path
 # run all python nosetests
 cd $GRAPHLAB_BUILD_ROOT/oss_src/unity/python
 make -j4
+pop_ld_library_path
 
 find . -name "*.xml" -delete
 if ! type "parallel" > /dev/null; then

--- a/oss_src/flexible_type/flexible_type_base_types.hpp
+++ b/oss_src/flexible_type/flexible_type_base_types.hpp
@@ -348,7 +348,9 @@ inline bool flex_type_is_convertible(flex_type_enum from, flex_type_enum to) {
 /*flt*/   {1,  1,  1,  0,  0,  0,  1,  0,  0},  // float casts to integer, self, string
 /*str*/   {0,  0,  1,  0,  0,  0,  0,  0,  0},  // string casts to string only
 /*vec*/   {0,  0,  1,  1,  1,  0,  0,  0,  0},  // vector casts to string and self and recursive
-/*rec*/   {0,  0,  1,  0,  1,  0,  0,  0,  0},  // recursive casts to string and self
+/*rec*/   {0,  0,  1,  0,  1,  0,  0,  0,  0},  // recursive casts to string and self. 
+                                                // technically a cast from rec to vec exists, but it could fail
+                                                // and so is not a reliable test for castability
 /*dic*/   {0,  0,  1,  0,  0,  1,  0,  0,  0},  // dict casts to self
 /*dtime*/ {1,  1,  1,  0,  0,  0,  1,  0,  0},  // dtime casts to string and self
 /*undef*/ {0,  0,  1,  0,  0,  0,  0,  1,  0},  //UNDEFINED casts to string and UNDEFINED 

--- a/oss_src/sframe_query_engine/operators/lambda_transform.hpp
+++ b/oss_src/sframe_query_engine/operators/lambda_transform.hpp
@@ -166,13 +166,13 @@ class operator_impl<planner_node_type::LAMBDA_TRANSFORM_NODE> : public query_ope
       flexible_type res(type);
       res.soft_assign(val);
       return res;
-    } else if (( (val.get_type() == flex_type_enum::VECTOR && 
-                  type == flex_type_enum::LIST) 
-                || (val.get_type() == flex_type_enum::LIST && 
-                  type == flex_type_enum::VECTOR)) 
-               && val.size() == 0) { 
+    } else if ( (val.get_type() == flex_type_enum::VECTOR && 
+                 type == flex_type_enum::LIST) 
+               || (val.get_type() == flex_type_enum::LIST && 
+                   type == flex_type_enum::VECTOR)) {
       // empty lists / vectors cast between each other.
       flexible_type res(type);
+      res.soft_assign(val);
       return res;
     } else {
       std::string message = "Cannot convert " + std::string(val) + 

--- a/oss_src/unity/python/sframe/cython/cy_server.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_server.pyx
@@ -105,9 +105,12 @@ class EmbeddedServer(GraphLabServer):
     def get_server_addr(self):
         return self.server_addr
 
-    def start(self):
+    def send_engine_start_metrics(self):
         _get_metric_tracker().track('engine-started', value=1, send_sys_info=True)
         _get_metric_tracker().track('engine-started-local', value=1, send_sys_info=True)
+
+    def start(self):
+        self.send_engine_start_metrics()
 
         if sys.platform == 'win32':
             self.unity_log += ".0"

--- a/oss_src/unity/python/sframe/data_structures/sframe.py
+++ b/oss_src/unity/python/sframe/data_structures/sframe.py
@@ -901,7 +901,7 @@ class SFrame(object):
             with cython_context():
                 if (_format == 'dataframe'):
                     for c in data.columns.values:
-                        self.add_column(SArray(data[c].values), c)
+                        self.add_column(SArray(data[c].values), str(c))
                 elif (_format == 'sframe_obj'):
                     for col in data.column_names():
                         self.__proxy__.add_column(data[col].__proxy__, col)

--- a/oss_src/unity/python/sframe/util/cloudpickle.py
+++ b/oss_src/unity/python/sframe/util/cloudpickle.py
@@ -726,11 +726,19 @@ def _fill_function(func, globals, defaults, closures, dict):
         that were created via _make_skel_func().
          """
     closure = _reconstruct_closure(closures) if closures else None
-    func = types.FunctionType(func.__code__, func.func_globals,
-            None, None, closure)
-    func.func_globals.update(globals)
-    func.func_defaults = defaults
-    func.func_dict = dict
+    if sys.version_info.major == 2:
+        func = types.FunctionType(func.__code__, func.func_globals,
+                None, None, closure)
+        func.func_globals.update(globals)
+        func.func_defaults = defaults
+        func.func_dict = dict
+    else:
+        func = types.FunctionType(func.__code__, func.__globals__,
+                None, None, closure)
+        func.__globals__.update(globals)
+        func.__defaults__ = defaults
+        func.__dict__ = dict
+
     return func
 
 


### PR DESCRIPTION
- fix to cloudpickle backward compatibility and recursive closure
  support. To maintain compatibility with the old cloudpickle, the
  argument structure to fill_function and make_skel_func must be
  maintained. Some modifications are added to amintain this.
- A regression was discovered where lambdas which returns lists cannot
  be correctly converted to array type.
- adding a little comment to flexible_type to avoid some
  misunderstandings
- Removed LD_LIBRARY_PATH setting in make_egg and python_env. That
causes more problems than it solves. Be a bit more strategic about when LD_LIBRARY_PATH is set.