### PR TITLE
Minor fix build script

### DIFF
--- a/oss_src/unity/python/sframe/CMakeLists.txt
+++ b/oss_src/unity/python/sframe/CMakeLists.txt
@@ -29,7 +29,6 @@ endforeach()
 set(INSTALLATION_BINARY_TARGETS
   unity_server
   ## spark_unity
-  pylambda_worker
   minipsutil
 )
 

--- a/oss_src/unity/python/sframe/cython/CMakeLists.txt
+++ b/oss_src/unity/python/sframe/cython/CMakeLists.txt
@@ -46,8 +46,7 @@ if(WIN32)
   make_copy_target(cython_deps ALL
     TARGETS
     ${UNITY_EXTENSION_LIBRARY}
-    unity_server
-    unity_toolkits_shared
+    ${INSTALLATION_BINARY_TARGETS}
     FILES
     ${INSTALLATION_BINARY_FILES}
     ${INSTALLATION_SYSTEM_BINARY_FILES}


### PR DESCRIPTION
Remove libpylambda_worker.a from binary copy target
Use "BINARY_INSTALL_TARGETS" in copy_cython_deps for windows.