### PR TITLE
Move requests to latest version

### DIFF
--- a/oss_src/unity/python/setup.py
+++ b/oss_src/unity/python/setup.py
@@ -158,7 +158,7 @@ if __name__ == '__main__':
             "decorator == 3.4.0",
             "tornado == 4.1",
             "prettytable == 0.7.2",
-            "requests == 2.3.0",
+            "requests == 2.9.1",
             "awscli == 1.6.2",
             "multipledispatch>=0.4.7",
             "certifi==2015.04.28" # we need to downgrade certifi to work with S3


### PR DESCRIPTION
Versions prior to 2.6 fail on Debian 8 because of that OS's lack of
opensslv3 support.