### PR TITLE
Remove Mixpanel tracking from SFrame

### DIFF
--- a/oss_local_scripts/pip_requirements.txt
+++ b/oss_local_scripts/pip_requirements.txt
@@ -1,7 +1,6 @@
 awscli==1.6.2
 httpretty==0.8.8
 librato-metrics==0.8.2
-mixpanel==4.2.0
 moto==0.4.1
 prettytable==0.7.2
 xmltodict==0.9.2

--- a/oss_src/unity/python/conf/dev.py
+++ b/oss_src/unity/python/conf/dev.py
@@ -9,5 +9,4 @@ graphlab_server = 'http://pws-billing-stage.herokuapp.com'
 
 mode = 'DEV'
 
-mixpanel_user = '97b6ae8fe096844c2efb9f6c57165d41'
 metrics_url = 'http://d11jde3m8wpum9.cloudfront.net/i'

--- a/oss_src/unity/python/conf/prod.py
+++ b/oss_src/unity/python/conf/prod.py
@@ -9,5 +9,4 @@ graphlab_server = 'https://beta.graphlab.com'
 
 mode = 'PROD'
 
-mixpanel_user = '97b6ae8fe096844c2efb9f6c57165d41'
 metrics_url = 'http://d3dou3jr4nway6.cloudfront.net/i'

--- a/oss_src/unity/python/conf/qa.py
+++ b/oss_src/unity/python/conf/qa.py
@@ -9,6 +9,5 @@ graphlab_server = 'http://pws-billing-stage.herokuapp.com'
 
 mode = 'QA'
 
-mixpanel_user = '97b6ae8fe096844c2efb9f6c57165d41'
 metrics_url = 'http://d343i1j50yi7ez.cloudfront.net/i'
 

--- a/oss_src/unity/python/conf/unit.py
+++ b/oss_src/unity/python/conf/unit.py
@@ -8,5 +8,4 @@ of the BSD license. See the LICENSE file for details.
 graphlab_server = 'http://pws-billing-stage.herokuapp.com'
 
 mode = 'UNIT'
-mixpanel_user = ''
 metrics_url = 'http://d11jde3m8wpum9.cloudfront.net/i'

--- a/oss_src/unity/python/setup.py
+++ b/oss_src/unity/python/setup.py
@@ -154,7 +154,6 @@ if __name__ == '__main__':
         classifiers=classifiers,
         install_requires=[
             "boto == 2.33.0",
-            "mixpanel == 4.2.0",
             "decorator == 3.4.0",
             "tornado == 4.1",
             "prettytable == 0.7.2",

--- a/oss_src/unity/python/sframe/util/config.py
+++ b/oss_src/unity/python/sframe/util/config.py
@@ -14,7 +14,7 @@ import sys as _sys
 class GraphLabConfig:
 
     __slots__ = ['graphlab_server', 'server_addr', 'server_bin', 'log_dir', 'unity_metric',
-                 'mode', 'mixpanel_user',
+                 'mode',
                  'log_rotation_interval','log_rotation_truncate', 'metrics_url']
 
     def __init__(self, server_addr=None):
@@ -67,7 +67,6 @@ class GraphLabConfig:
         except ImportError:
           self.graphlab_server = ''
           self.mode = 'UNIT'
-          self.mixpanel_user = ''
           self.metrics_url = ''
         else:
           if graphlab_env.mode in ['UNIT', 'DEV', 'QA', 'PROD']:
@@ -75,7 +74,6 @@ class GraphLabConfig:
           else:
             self.mode = 'PROD'
 
-          self.mixpanel_user = graphlab_env.mixpanel_user
           self.graphlab_server = graphlab_env.graphlab_server
           self.metrics_url = graphlab_env.metrics_url
 

--- a/oss_src/unity/python/sframe/util/metric_tracker.py
+++ b/oss_src/unity/python/sframe/util/metric_tracker.py
@@ -10,7 +10,6 @@ from .metric_mock import MetricMock
 from .sys_info import get_distinct_id, get_sys_info, get_version, get_isgpu, get_build_number
 
 
-import Queue
 import logging
 import pprint
 import threading

--- a/oss_src/unity/python/sframe/util/metric_tracker.py
+++ b/oss_src/unity/python/sframe/util/metric_tracker.py
@@ -10,9 +10,7 @@ from .metric_mock import MetricMock
 from .sys_info import get_distinct_id, get_sys_info, get_version, get_isgpu, get_build_number
 
 
-# metrics libraries
-import mixpanel
-
+import Queue
 import logging
 import pprint
 import threading
@@ -58,8 +56,6 @@ class _MetricsWorkerThread(threading.Thread):
     root_package_name = __import__(__name__.split('.')[0]).__name__
     self.logger = logging.getLogger(root_package_name + '.metrics')
 
-    self._mixpanel = None # Mixpanel metrics tracker
-
     buffer_size = 5
     offline_buffer_size = 25
     self._sys_info_set = False
@@ -70,10 +66,6 @@ class _MetricsWorkerThread(threading.Thread):
       self._metrics_url = CONFIG.metrics_url
       self._requests = _requests # support mocking out requests library in unit-tests
 
-      if self._mode != 'PROD':
-        self._mixpanel = MetricMock()
-      else:
-        self._mixpanel = mixpanel.Mixpanel(CONFIG.mixpanel_user)
     except Exception as e:
       self.logger.warning("Unexpected exception connecting to Metrics service, disabling metrics, exception %s" % e)
     else:
@@ -99,51 +91,6 @@ class _MetricsWorkerThread(threading.Thread):
       except Exception as e:
         pass
 
-  @staticmethod
-  def _get_bucket_name_suffix(buckets, value):
-    """
-    Given a list of buckets and a value, generate a suffix for the bucket
-    name, corresponding to either one of the buckets given, or the largest
-    bucket with "+" appended.
-    """
-    suffix = None
-    for bucket in buckets:
-        if value <= bucket:
-            suffix = str(bucket)
-            break
-    # if we get here and suffix is None, value must be > the largest bucket
-    if suffix is None:
-        suffix = '%d+' % buckets[-1]
-    return suffix
-
-  @staticmethod
-  def _bucketize_mixpanel(event_name, value):
-    """
-    Take events that we would like to bucketize and bucketize them before sending to mixpanel
-
-    @param event_name current event name, used to assess if bucketization is required
-    @param value value used to decide which bucket for event
-    @return event_name if updated then will have bucket appended as suffix, otherwise original returned
-    """
-
-    if value == 1:
-        return event_name
-
-    bucket_events = {
-        'col.size': [ 5, 10, 20 ],
-        'row.size': [ 100000, 1000000, 10000000, 100000000 ],
-        'duration.secs': [ 300, 1800, 3600, 7200 ],
-        'duration.ms': [ 10, 100, 1000, 10000, 100000 ]
-    }
-
-    for (event_suffix, buckets) in bucket_events.items():
-        if event_name.endswith(event_suffix):
-            # if the suffix matches one we expect, bucketize using the buckets defined above
-            return '%s.%s' % (event_name, _MetricsWorkerThread._get_bucket_name_suffix(buckets, value))
-
-    # if there was no suffix match, just use the original event name
-    return event_name
-
   def _set_sys_info(self):
     # Don't do this if system info has been set
     if self._sys_info_set:
@@ -154,19 +101,6 @@ class _MetricsWorkerThread(threading.Thread):
   def _print_sys_info(self):
     pp = pprint.PrettyPrinter(indent=2)
     pp.pprint(self._sys_info)
-
-  def _send_mixpanel(self, event_name, value, properties, meta):
-    # Only send 'engine-started' events to Mixpanel. All other events are not sent to Mixpanel.
-    if 'engine-started' in event_name:
-      try:
-        # since mixpanel cannot send sizes or numbers, just tracks events, bucketize these here
-        if value != 1:
-          event_name = self._bucketize_mixpanel(event_name, value)
-          properties['value'] = value
-        properties['source'] = self._source
-        self._mixpanel.track(self._distinct_id, event_name, properties=properties, meta=meta)
-      except Exception as e:
-        pass
 
   def _track(self, event_name, value=1, type="gauge", properties={}, meta={}, send_sys_info=False):
     """
@@ -182,8 +116,6 @@ class _MetricsWorkerThread(threading.Thread):
       the_properties.update(self._sys_info)
 
     the_properties.update(properties)
-
-    self._send_mixpanel(event_name=event_name, value=value, properties=the_properties, meta=meta)
 
     try:
       # homebrew metrics - cloudfront


### PR DESCRIPTION
This change removes Mixpanel tracking from SFrame (was only tracking engine-started events). Metrics tracking still goes to CloudFront (if GLC license is present). The bucketize logic was only being used by Mixpanel so that is removed as well.