### PR TITLE
fix logprogress miss the very first print

### DIFF
--- a/oss_src/unity/server/unity_server.cpp
+++ b/oss_src/unity/server/unity_server.cpp
@@ -60,8 +60,6 @@ void unity_server::start(const unity_server_initializer& server_initializer) {
                                    options.publish_address,
                                    options.secret_key);
 
-  set_log_progress(true);
-
   // initialize built-in data structures, toolkits and models, defined in unity_server_init.cpp
   server_initializer.init_toolkits(*toolkit_functions);
   server_initializer.init_models(*toolkit_classes);


### PR DESCRIPTION
On engine start the logprogress handler was automatically set to
default std:cout handler. Disable that and only use the python
callback handler seems to fix the issue.