### PR TITLE
Extend and fix the callback interface

### DIFF
--- a/oss_src/unity/extensions/additional_sframe_utilities.cpp
+++ b/oss_src/unity/extensions/additional_sframe_utilities.cpp
@@ -12,35 +12,36 @@
 #include <unity/lib/toolkit_function_macros.hpp>
 using namespace graphlab;
 
-void sarray_callback(graphlab::gl_sarray input, size_t callback_addr,
+void sarray_callback(graphlab::gl_sarray input, size_t callback_addr, size_t callback_data_addr,
                      size_t begin, size_t end) {
-  typedef bool(*callback_type)(const flexible_type*);
+  typedef bool(*callback_type)(const flexible_type*, void*);
   callback_type callback_fun = (callback_type)(callback_addr);
   auto ra = input.range_iterator(begin, end);
   auto iter = ra.begin();
   while (iter != ra.end()) {
-    bool success = callback_fun(&(*iter));
+    bool success = callback_fun(&(*iter), (void*)(callback_data_addr));
     if (!success) log_and_throw("Error applying callback");
     ++iter;
   }
 }
 
-void sframe_callback(graphlab::gl_sframe input, size_t callback_addr,
+void sframe_callback(graphlab::gl_sframe input, size_t callback_addr, size_t callback_data_addr,
                      size_t begin, size_t end) {
   ASSERT_MSG(input.num_columns() > 0, "SFrame has no column");
-  typedef bool(*callback_type)(const flexible_type*, size_t);
+  typedef bool(*callback_type)(const flexible_type*, size_t, void*);
   callback_type callback_fun = (callback_type)(callback_addr);
   auto ra = input.range_iterator(begin, end);
+  std::vector<flexible_type> row_vec;
   auto iter = ra.begin();
   while (iter != ra.end()) {
-    auto& row_vec = (*iter);
-    bool success = callback_fun(&(row_vec[0]), row_vec.size());
+    row_vec = (*iter);
+    bool success = callback_fun(&(row_vec[0]), row_vec.size(), (void*)(callback_data_addr));
     if (!success) log_and_throw("Error applying callback");
     ++iter;
   }
 }
 
 BEGIN_FUNCTION_REGISTRATION
-REGISTER_FUNCTION(sarray_callback, "input", "callback_addr", "begin", "end");
-REGISTER_FUNCTION(sframe_callback, "input", "callback_addr", "begin", "end");
+REGISTER_FUNCTION(sarray_callback, "input", "callback_addr", "callback_data", "begin", "end");
+REGISTER_FUNCTION(sframe_callback, "input", "callback_addr", "callback_data", "begin", "end");
 END_FUNCTION_REGISTRATION


### PR DESCRIPTION
Added void* to support callback data.
The bug is due to range_iterator dereferences to sframe_row::row not
std::vector. sframe_row::row is a row wrapper over column store, hense does not have the contiguous memory,
expected by the callback function. The fix is to copy it into contiguous memory.