### PR TITLE
Add SFrame recognition for two types

### DIFF
--- a/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_flexible_type.pyx
@@ -1233,6 +1233,7 @@ cdef inline tr_datetime64_to_ft(flexible_type& ret, v):
     if as_py_datetime is not None:
         as_py_datetime = as_py_datetime.replace(tzinfo=GMT(0))
         tr_datetime_to_ft(ret, as_py_datetime)
+    # else, ret stays as FLEX_UNDEFINED
 
 
 ################################################################################
@@ -1429,20 +1430,18 @@ cdef flexible_type _ft_translate(object v, int tr_code) except *:
         ret = FLEX_UNDEFINED
         return ret
     elif tr_code == (FT_DATETIME_TYPE + FT_SAFE):
-      if HAS_NUMPY and isinstance(v, np.datetime64):
-          if v == np.datetime64('NaT'):
-              ret = FLEX_UNDEFINED
-          else:
-              tr_datetime64_to_ft(ret, v)
-      elif HAS_PANDAS and isinstance(v, pd.Timestamp):
+        ret = FLEX_UNDEFINED
+        if HAS_NUMPY and isinstance(v, np.datetime64):
+          tr_datetime64_to_ft(ret, v)
+        elif HAS_PANDAS and isinstance(v, pd.Timestamp):
           tr_datetime_to_ft(ret, v.to_datetime())
-      elif isinstance(v, datetime.datetime):
+        elif isinstance(v, datetime.datetime):
           tr_datetime_to_ft(ret, v)
-      else:
+        else:
           # This should catch only datetime.date, since the check for
           # datetime.datetime is before it
           tr_datetime_to_ft(ret, datetime.datetime(v.year, v.month, v.day))
-      return ret
+        return ret
     elif tr_code == (FT_IMAGE_TYPE + FT_SAFE):
         if type(v) != _image_type:
             raise TypeError("Cannot interpret type '" + str(type(v)) + "' as graphlab.Image type.")

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -2575,6 +2575,10 @@ class SArrayTest(unittest.TestCase):
         sa = SArray(iso_str_list)
         self.__test_equal(sa,expected,dt.datetime)
 
+        iso_str_list[2] = np.datetime64('NaT')
+        sa = SArray(iso_str_list)
+        self.__test_equal(sa,expected,dt.datetime)
+
         # A numpy array
         np_ary = np.array(iso_str_list)
         sa = SArray(np_ary)
@@ -2618,6 +2622,10 @@ class SArrayTest(unittest.TestCase):
         iso_str_list = [pd.Timestamp('2013-05-07T10:04:10'),
                         pd.Timestamp('1902-10-21T10:34:10Z'),
                         None]
+        sa = SArray(iso_str_list)
+        self.__test_equal(sa,self.datetime_data,dt.datetime)
+
+        iso_str_list[2] = pd.tslib.NaT
         sa = SArray(iso_str_list)
         self.__test_equal(sa,self.datetime_data,dt.datetime)
 

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -2629,3 +2629,15 @@ class SArrayTest(unittest.TestCase):
         expected =  [dt.datetime(2016,1,1,5,45,0,tzinfo=GMT(5.75))]
         self.__test_equal(sa, expected, dt.datetime)
 
+    def test_decimal(self):
+        import decimal
+        test_val = decimal.Decimal(3.0)
+        sa = SArray([test_val])
+        expected = [3.0]
+        self.__test_equal(sa, expected, float)
+
+    def test_timedelta(self):
+        test_val = dt.timedelta(1,1)
+        sa = SArray([test_val])
+        expected = [86401.0]
+        self.__test_equal(sa, expected, float)


### PR DESCRIPTION
Types are decimal.Decimal and datetime.timedelta, both converted to
float. The timedelta type will represent the number of seconds in the
interval.

Also handles the case of the NaT (Not a Time) type in pandas and numpy.

Addresses https://github.com/dato-code/documents/issues/3717
and https://github.com/dato-code/documents/issues/3755