### PR TITLE
Allow cpp->unicode to be cpp->bytes if needed.

### DIFF
--- a/oss_src/unity/python/sframe/cython/cy_cpp_utils.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_cpp_utils.pxd
@@ -45,12 +45,22 @@ cdef inline string unsafe_unicode_to_cpp(py_s) except *:
         return (<str>py_s).encode()
     else:
         return (<unicode>py_s).encode('UTF-8')
-            
-cdef inline str cpp_to_str(const string& cpp_s):
+
+# With cpp_to_str, a c++ string is decoded into bytes if
+# disable_cpp_str_decode() has been called, or str otherwise.  If
+# decoding is done into bytes, as is needed by some contexts, then
+# enable_cpp_str_decode() should be called immediately afterwards --
+# i.e. use a try...finally block!
+    
+cpdef disable_cpp_str_decode()
+cpdef enable_cpp_str_decode()
+cdef _cpp_to_str_py3_decode(const string& cpp_s)
+                
+cdef inline cpp_to_str(const string& cpp_s):
     cdef const char* c_s = cpp_s.data()
     
     if PY_MAJOR_VERSION >= 3:
-        return c_s[:cpp_s.size()].decode()
+        return _cpp_to_str_py3_decode(cpp_s)
     else:
         return str(c_s[:cpp_s.size()])
 

--- a/oss_src/unity/python/sframe/cython/cy_cpp_utils.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_cpp_utils.pyx
@@ -52,3 +52,28 @@ cdef string _attempt_cast_str_to_cpp(py_s) except *:
 
     # Okay, none of these worked, so error out.
     raise TypeError("Type '%s' cannot be interpreted as str." % str(type(py_s)))
+
+
+cdef bint _cpp_to_str_py3_decode_enabled = True
+
+cpdef disable_cpp_str_decode():
+    global _cpp_to_str_py3_decode_enabled
+    assert _cpp_to_str_py3_decode_enabled == True
+    _cpp_to_str_py3_decode_enabled = False
+
+cpdef enable_cpp_str_decode():
+    global _cpp_to_str_py3_decode_enabled
+    assert _cpp_to_str_py3_decode_enabled == False
+    _cpp_to_str_py3_decode_enabled = True
+
+cdef _cpp_to_str_py3_decode(const string& cpp_s):
+    """
+    Decodes a c++ string into bytes if disable_cpp_str_decode() has
+    been called, or str otherwise.
+    """
+    cdef const char* c_s = cpp_s.data()
+
+    if _cpp_to_str_py3_decode_enabled:
+        return c_s[:cpp_s.size()].decode()
+    else:
+        return <bytes>(c_s[:cpp_s.size()])


### PR DESCRIPTION
This is needed to get load_model to work in python 3.