### PR TITLE
new version of spark_unity.jar (version 0.5)

### DIFF
--- a/oss_src/sframe/CMakeLists.txt
+++ b/oss_src/sframe/CMakeLists.txt
@@ -52,6 +52,7 @@ REQUIRES
   flexible_type sframe fileio python_callbacks 
 )
 
-file(DOWNLOAD http://s3-us-west-2.amazonaws.com/glbin-engine/spark_unity_0.4.jar ${CMAKE_CURRENT_BINARY_DIR}/spark_unity.jar
-      EXPECTED_MD5 1ff73889a5484a90b0f1675641c16488)
+file(DOWNLOAD http://s3-us-west-2.amazonaws.com/glbin-engine/spark_unity_0.5.jar ${CMAKE_CURRENT_BINARY_DIR}/spark_unity.jar
+      EXPECTED_MD5 5cdec61c6b5d0352f344db4ef81f50ea)
+
 


### PR DESCRIPTION
Version 0.5 of spark_unity.jar file (sync with the latest commit master in https://github.com/dato-code/spark-sframe).

Major changes in jar file are: 

1) remove dependency to custom pickler.
2) better support for nested data structure (json format).
3) better support for dataframe of map type.
4) datetime conversion is now supported (no timezone).
5) remove dependency to boost::python.
6) fix issue of dataframe of int with null values. 


