### PR TITLE
Fix #178

### DIFF
--- a/oss_src/unity/lib/gl_sarray.hpp
+++ b/oss_src/unity/lib/gl_sarray.hpp
@@ -1028,7 +1028,7 @@ class gl_sarray {
   gl_sarray sample(double fraction, size_t seed) const;
 
   /**
-   * Return true if every element of the \ref gl_sarray evaluates to false. For
+   * Return true if every element of the \ref gl_sarray evaluates to true. For
    * numeric \ref gl_sarray objects zeros and missing values ("None") evaluate
    * to false, while all non-zero, non-missing values evaluate to true. For
    * string, list, and dictionary \ref gl_sarray objects, empty values (zero

--- a/oss_src/unity/lib/unity_sarray.cpp
+++ b/oss_src/unity/lib/unity_sarray.cpp
@@ -1416,7 +1416,8 @@ std::shared_ptr<unity_sarray_base> unity_sarray::scalar_operator(flexible_type o
 
   // create the lazy evalation transform operator from the source
   std::shared_ptr<unity_sarray> ret_unity_sarray(new unity_sarray());
-  if (other.get_type() != flex_type_enum::UNDEFINED) {
+  bool op_is_not_equality_compare = (op != "==" && op != "!=");
+  if (other.get_type() != flex_type_enum::UNDEFINED && op_is_not_equality_compare) {
     auto transformfn = [=](const flexible_type& f)->flexible_type {
           if (f.get_type() == flex_type_enum::UNDEFINED) {
             return f;

--- a/oss_test/unity/unity_sarray.cxx
+++ b/oss_test/unity/unity_sarray.cxx
@@ -828,11 +828,13 @@ class unity_sarray_test: public CxxTest::TestSuite {
     __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, ">="), 1);
     __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, "<"), 0);
     __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, "<="), 1);
-    __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, "=="), 1);
-    __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(1, "!="), 1);
-    __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, "!="), 0);
     __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(1, "%"), 0);
     __test_numeric_ops_values_and_clean(dbl.left_scalar_operator(2, "%"), 0);
+
+    // None != (int)x for all x
+    __test_numeric_ops_values_and_clean_no_missing(dbl.left_scalar_operator(2, "=="), 0, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.left_scalar_operator(1, "!="), 1, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.left_scalar_operator(2, "!="), 1, 0);
 
     // these do not change types
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(1, "+"), 3);
@@ -842,11 +844,14 @@ class unity_sarray_test: public CxxTest::TestSuite {
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, ">="), 1);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "<"), 0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "<="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "=="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(1, "!="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "!="), 0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "%"), 0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(5, "%"), 1);
+
+    // (int)x != None for all x
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(2, "=="), 0, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(1, "!="), 1, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(2, "!="), 1, 0);
+
 
     // these change types
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2, "/"), 1.0);
@@ -854,14 +859,17 @@ class unity_sarray_test: public CxxTest::TestSuite {
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(1.0, "-"), -1.0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "*"), 4.0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "/"), 1.0);
+
     // these still do not change types
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, ">"), 0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, ">="), 1);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "<"), 0);
     __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "<="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "=="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(1.0, "!="), 1);
-    __test_numeric_ops_values_and_clean(dbl.right_scalar_operator(2.0, "!="), 0);
+
+    // (float)x != None for all x (should return int)
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(2.0, "=="), 0, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(1.0, "!="), 1, 1);
+    __test_numeric_ops_values_and_clean_no_missing(dbl.right_scalar_operator(2.0, "!="), 1, 0);
   }
 
 
@@ -972,6 +980,7 @@ class unity_sarray_test: public CxxTest::TestSuite {
   void test_string_scalar_ops() {
     // make a vector with an UNDEFINED first value
     std::vector<flexible_type> vec{"a","a","a","a","a","a","a","a","a","a"};
+
     // one missing at 0 to test missing propagation
     vec[0] = flexible_type(flex_type_enum::UNDEFINED);
 
@@ -993,8 +1002,10 @@ class unity_sarray_test: public CxxTest::TestSuite {
     __test_numeric_ops_values_and_clean(dbl->left_scalar_operator("b", ">"), 0);
     __test_numeric_ops_values_and_clean(dbl->left_scalar_operator("b", "<="), 1);
     __test_numeric_ops_values_and_clean(dbl->left_scalar_operator("b", ">="), 0);
-    __test_numeric_ops_values_and_clean(dbl->left_scalar_operator("b", "=="),  0);
-    __test_numeric_ops_values_and_clean(dbl->left_scalar_operator("b", "!="), 1);
+
+    // (std::string)s != None
+    __test_numeric_ops_values_and_clean_no_missing(dbl->left_scalar_operator("b", "=="), 0, 0);
+    __test_numeric_ops_values_and_clean_no_missing(dbl->left_scalar_operator("b", "!="), 1, 1);
   }
 
   void test_string_in() {


### PR DESCRIPTION
Fix boolean logic using `None` values. Note that behavior with this pull request is not entirely equivalent to Python: it only changes the `None`-handling behavior of the `==` and `!=` operators, while Python also allows `<`, `>`, `<=`, and `>=`. Python's behavior for these comparators is to treat `None` as less than all numbers. This would be a fairly easy change to make to behave like Python, but I think passing `None` through may be more useful.