### PR TITLE
Fix the 'w' option in generate_random_sframe

### DIFF
--- a/oss_src/unity/extensions/random_sframe_generation.cpp
+++ b/oss_src/unity/extensions/random_sframe_generation.cpp
@@ -130,6 +130,8 @@ gl_sframe _generate_random_sframe(size_t n_rows, std::string column_types,
 
       case 'v':
       case 'V':
+      case 'w':
+      case 'W':
         types[c_idx] = flex_type_enum::VECTOR;
         break;
 


### PR DESCRIPTION
This was failing with an AssertionError in run_toolkit_function or something. This seems to fix it.