### PR TITLE
Fix confusing IO error message

### DIFF
--- a/oss_src/unity/lib/unity_sframe.cpp
+++ b/oss_src/unity/lib/unity_sframe.cpp
@@ -77,7 +77,7 @@ void unity_sframe::construct_from_sframe_index(std::string location) {
   clear();
 
   auto status = fileio::get_file_status(location);
-  if (fileio::is_web_protocol(location)) {
+  if (fileio::is_web_protocol(fileio::get_protocol(location))) {
     // if it is a web protocol, we cannot be certain what type of file it is.
     // HEURISTIC:
     //   assume it is a "directory" and try to load dir_archive.ini

--- a/oss_src/unity/python/sframe/util/__init__.py
+++ b/oss_src/unity/python/sframe/util/__init__.py
@@ -220,9 +220,13 @@ def _make_internal_url(url):
             raise ValueError("HDFS URL is not supported because Hadoop not found. Please make hadoop available from PATH or set the environment variable HADOOP_HOME and try again.")
     elif protocol == 's3':
         return _try_inject_s3_credentials(url)
-    elif protocol == '' or (protocol == 'local' or protocol == 'remote'):
+    elif protocol == '':
+        is_local = True
+    elif (protocol == 'local' or protocol == 'remote'):
         # local and remote are legacy protocol for seperate server process
         is_local = True
+        # This code assumes local and remote are same machine
+        url = _re.sub(protocol+'://','',url,count=1)
     else:
         raise ValueError('Invalid url protocol %s. Supported url protocols are: local, s3://, https:// and hdfs://' % protocol)
 


### PR DESCRIPTION
Fixes issue #254

The right error message was always there, we were just detecting
everything as a web protocol. That's fixed.

Also fixed the deprecated "local://" and "remote://" paths. For kicks
mostly.