### PR TITLE
Improved .contains(), list to array.array casting. Operator code cleanup

### DIFF
--- a/oss_src/unity/lib/unity_sarray.cpp
+++ b/oss_src/unity/lib/unity_sarray.cpp
@@ -1211,7 +1211,8 @@ std::shared_ptr<unity_sarray_base> unity_sarray::lazy_astype(flex_type_enum dtyp
         (current_type == flex_type_enum::STRING && dtype == flex_type_enum::FLOAT) ||
         (current_type == flex_type_enum::STRING && dtype == flex_type_enum::VECTOR) ||
         (current_type == flex_type_enum::STRING && dtype == flex_type_enum::LIST) ||
-        (current_type == flex_type_enum::STRING && dtype == flex_type_enum::DICT)
+        (current_type == flex_type_enum::STRING && dtype == flex_type_enum::DICT) ||
+        (current_type == flex_type_enum::LIST&& dtype == flex_type_enum::VECTOR)
        )) {
     log_and_throw("Not able to cast to given type");
   }
@@ -1271,6 +1272,34 @@ std::shared_ptr<unity_sarray_base> unity_sarray::lazy_astype(flex_type_enum dtyp
       return ret;
     };
 
+    auto ret = transform_lambda(transform_fn, 
+                                dtype,
+                                true /*skip undefined*/, 
+                                0 /*random seed*/);
+    return ret;
+
+  } else if (current_type == flex_type_enum::LIST && dtype == flex_type_enum::VECTOR) {
+    // a lambda that converts list to vector, one element at a time
+    auto transform_fn = [undefined_on_failure](const flexible_type& f)->flexible_type {
+      if (f.get_type() == flex_type_enum::UNDEFINED) return f;
+      // input
+      const flex_list& src = f.get<flex_list>();
+      // output
+      flex_vec ret;
+      ret.resize(src.size());
+
+      for (size_t i = 0;i < src.size(); ++i) {
+        auto src_type = src[i].get_type();
+        if (src_type == flex_type_enum::INTEGER || src_type == flex_type_enum::FLOAT) {
+          ret[i] = (flex_float)(src[i]);
+        } else {
+          // not convertible.
+          if (undefined_on_failure) return FLEX_UNDEFINED;
+          else log_and_throw("Unable to interpret " + flex_string(f) + " as a numeric array");
+        }
+      }
+      return ret;
+    };
     auto ret = transform_lambda(transform_fn, 
                                 dtype,
                                 true /*skip undefined*/, 

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -709,13 +709,20 @@ class SArray(object):
 
     def contains(self, item):
         """
-        Performs an element-wise substring search of "item". The current
-        array must contains strings and item must be a string. Produces a 1
-        for each row if item is a substring of the row and 0 otherwise.
+        Performs an element-wise search of "item" in the SArray.
 
         Conceptually equivalent to:
 
         >>> sa.apply(lambda x: item in x)
+        
+        If the current SArray contains strings and item is a string. Produces a 1
+        for each row if 'item' is a substring of the row and 0 otherwise.
+
+        If the current SArray contains list or arrays, this produces a 1
+        for each row if 'item' is an element of the list or array.
+
+        If the current SArray contains dictionaries, this produces a 1
+        for each row if 'item' is a key in the dictionary.
 
         Parameters
         ----------
@@ -734,6 +741,14 @@ class SArray(object):
         dtype: int
         Rows: 3
         [1, 0, 0]
+        >>> SArray([['a','b'],['b','c'],['c','d']]).contains("b")
+        dtype: int
+        Rows: 3
+        [1, 1, 0]
+        >>> SArray([{'a':1},{'a':2,'b':1}, {'c':1}]).contains("a")
+        dtype: int
+        Rows: 3
+        [1, 1, 0]
         """
         return SArray(_proxy = self.__proxy__.left_scalar_operator(item, 'in'))
 

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -726,31 +726,78 @@ class SArray(object):
 
         Parameters
         ----------
-        item : str
+        item : any type
             The item to search for.
 
         Returns
         -------
         out : SArray
-            A binary SArray where a non-zero value denotes that the string
-            was found in the SArray. And 0 if it is not found.
+            A binary SArray where a non-zero value denotes that the item 
+            was found in the row. And 0 if it is not found.
 
         Examples
         --------
-        >>> SArray(["abc","def","ghi"]).contains("a")
+        >>> SArray(['abc','def','ghi']).contains('a')
         dtype: int
         Rows: 3
         [1, 0, 0]
-        >>> SArray([['a','b'],['b','c'],['c','d']]).contains("b")
+        >>> SArray([['a','b'],['b','c'],['c','d']]).contains('b')
         dtype: int
         Rows: 3
         [1, 1, 0]
-        >>> SArray([{'a':1},{'a':2,'b':1}, {'c':1}]).contains("a")
+        >>> SArray([{'a':1},{'a':2,'b':1}, {'c':1}]).contains('a')
         dtype: int
         Rows: 3
         [1, 1, 0]
+
+        See Also
+        --------
+        is_in 
         """
         return SArray(_proxy = self.__proxy__.left_scalar_operator(item, 'in'))
+
+
+    def is_in(self, other):
+        """
+        Performs an element-wise search for each row in 'other'.
+
+        Conceptually equivalent to:
+
+        >>> sa.apply(lambda x: x in other)
+        
+        If the current SArray contains strings and other is a string. Produces a 1
+        for each row if the row is a substring of 'other', and 0 otherwise.
+
+        If the 'other' is a list or array, this produces a 1
+        for each row if the row is an element of 'other'
+
+        Parameters
+        ----------
+        other : list, array.array, str
+            The variable to search in.
+
+        Returns
+        -------
+        out : SArray
+            A binary SArray where a non-zero value denotes that row was
+            was found in 'other'. And 0 if it is not found.
+
+        Examples
+        --------
+        >>> SArray(['ab','bc','cd']).is_in('abc')
+        dtype: int
+        Rows: 3
+        [1, 1, 0]
+        >>> SArray(['a','b','c']).is_in(['a','b'])
+        dtype: int
+        Rows: 3
+        [1, 1, 0]
+
+        See Also
+        --------
+        contains
+        """
+        return SArray(_proxy = self.__proxy__.right_scalar_operator(other, 'in'))
 
     # XXX: all of these functions are highly repetitive
     def __add__(self, other):

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -139,6 +139,23 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(sstr.contains("ll"), ["ll" in i for i in self.string_data], int)
         self.__test_equal(sstr.contains("a"), ["a" in i for i in self.string_data], int)
 
+        svec = SArray([[1.0,2.0],[2.0,3.0],[3.0,4.0],[4.0,5.0]], array.array)
+        self.__test_equal(svec.contains(1.0), [1,0,0,0], int)
+        self.__test_equal(svec.contains(0.0), [0,0,0,0], int)
+        self.__test_equal(svec.contains(2), [1,1,0,0], int)
+
+        slist = SArray([[1,"22"],[2,"33"],[3,"44"],[4,"55"]], list)
+        self.__test_equal(slist.contains(1.0), [1,0,0,0], int)
+        self.__test_equal(slist.contains(3), [0,0,1,0], int)
+        self.__test_equal(slist.contains("33"), [0,1,0,0], int)
+        self.__test_equal(slist.contains("3"), [0,0,0,0], int)
+
+        sdict = SArray([{1:"2"},{2:"3"},{3:"4"},{"4":"5"}], dict)
+        self.__test_equal(sdict.contains(1.0), [1,0,0,0], int)
+        self.__test_equal(sdict.contains(3), [0,0,1,0], int)
+        self.__test_equal(sdict.contains("4"), [0,0,0,1], int)
+        self.__test_equal(sdict.contains("3"), [0,0,0,0], int)
+
     def test_save_load(self):
         # Make sure these files don't exist before testing
         self._remove_sarray_files("intarr")
@@ -465,6 +482,18 @@ class SArrayTest(unittest.TestCase):
         s = SArray(["{1xyz:1a,2b:2}"])
         ret = list(s.astype(dict).head(1))
         self.assertEqual(ret, [{"1xyz":"1a","2b":2}])
+
+        # astype between list and array
+        s = SArray([array.array('d',[1.0,2.0]), array.array('d',[2.0,3.0])])
+        ret = list(s.astype(list))
+        self.assertEqual(ret, [[1.0, 2.0], [2.0,3.0]])
+        ret = list(s.astype(list).astype(array.array))
+        self.assertEqual(list(s), list(ret))
+        with self.assertRaises(RuntimeError):
+            ret = list(SArray([["a",1.0],["b",2.0]]).astype(array.array))
+
+        badcast = list(SArray([["a",1.0],["b",2.0]]).astype(array.array, undefined_on_failure=True))
+        self.assertEqual(badcast, [None, None])
 
     def test_clip(self):
         # invalid types

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -144,17 +144,25 @@ class SArrayTest(unittest.TestCase):
         self.__test_equal(svec.contains(0.0), [0,0,0,0], int)
         self.__test_equal(svec.contains(2), [1,1,0,0], int)
 
-        slist = SArray([[1,"22"],[2,"33"],[3,"44"],[4,"55"]], list)
+        slist = SArray([[1,"22"],[2,"33"],[3,"44"],[4,None]], list)
         self.__test_equal(slist.contains(1.0), [1,0,0,0], int)
         self.__test_equal(slist.contains(3), [0,0,1,0], int)
         self.__test_equal(slist.contains("33"), [0,1,0,0], int)
         self.__test_equal(slist.contains("3"), [0,0,0,0], int)
+        self.__test_equal(slist.contains(None), [0,0,0,1], int)
 
         sdict = SArray([{1:"2"},{2:"3"},{3:"4"},{"4":"5"}], dict)
         self.__test_equal(sdict.contains(1.0), [1,0,0,0], int)
         self.__test_equal(sdict.contains(3), [0,0,1,0], int)
         self.__test_equal(sdict.contains("4"), [0,0,0,1], int)
         self.__test_equal(sdict.contains("3"), [0,0,0,0], int)
+
+
+        self.__test_equal(SArray(['ab','bc','cd']).is_in('abc'), [1,1,0], int)
+        self.__test_equal(SArray(['a','b','c']).is_in(['a','b']), [1,1,0], int)
+        self.__test_equal(SArray([1,2,3]).is_in(array.array('d',[1.0,2.0])), [1,1,0], int)
+        self.__test_equal(SArray([1,2,None]).is_in([1, None]), [1,0,1], int)
+        self.__test_equal(SArray([1,2,None]).is_in([1]), [1,0,0], int)
 
     def test_save_load(self):
         # Make sure these files don't exist before testing


### PR DESCRIPTION
 - sarray.contains() can now query inside a list, an array, and a dict (for keys)
 - Added an sarray.is_in() which is the inverse of sarray.contains()
 - We can now cast from list to array
 - Some code cleanup in operators. There was some really strange handling of vector types.