### PR TITLE
Improved robustness of the test_pylambda_worker script on Mac.

### DIFF
--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -127,11 +127,18 @@ def test_pylambda_worker():
     environment = os.environ.copy()
     
     from os.path import join
+    from os.path import exists
     import tempfile
     import subprocess
     import datetime
     import time
     import zipfile
+    import sys
+    # change the temp directory to /tmp.
+    # Otherwise we get interesting zeromq "too long file name" issues.
+    if sys.platform == 'darwin':
+        if exists('/tmp'):
+            tempfile.tempdir = '/tmp'
 
     temp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
 - Sometimes we hit interesting long filename issues with zeromq with
 the default $TMPDIR. change TMPDIR to /tmp before running the script.