### PR TITLE
Fixed some lambda worker races

### DIFF
--- a/oss_src/fault/CMakeLists.txt
+++ b/oss_src/fault/CMakeLists.txt
@@ -22,6 +22,7 @@ make_library(fault_comm
   network
   util
   parallel
+  logger
 )
 set_property(TARGET fault_comm APPEND PROPERTY COMPILE_DEFINITIONS FAKE_ZOOKEEPER) 
 
@@ -48,6 +49,7 @@ make_library(fault_comm_zookeeper
   network
   util
   parallel
+  logger
 )
 else()
   make_empty_library(fault_comm_zookeeper fault_comm)

--- a/oss_src/fault/CMakeLists.txt
+++ b/oss_src/fault/CMakeLists.txt
@@ -21,6 +21,7 @@ make_library(fault_comm
   zeromq
   network
   util
+  parallel
 )
 set_property(TARGET fault_comm APPEND PROPERTY COMPILE_DEFINITIONS FAKE_ZOOKEEPER) 
 
@@ -46,6 +47,7 @@ make_library(fault_comm_zookeeper
   zookeeper_util
   network
   util
+  parallel
 )
 else()
   make_empty_library(fault_comm_zookeeper fault_comm)

--- a/oss_src/fault/sockets/async_reply_socket.cpp
+++ b/oss_src/fault/sockets/async_reply_socket.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <parallel/atomic.hpp>
 #include <boost/bind.hpp>
+#include <logger/logger.hpp>
 #include <fault/sockets/socket_errors.hpp>
 #include <fault/sockets/socket_config.hpp>
 #include <fault/sockets/async_reply_socket.hpp>
@@ -247,7 +248,7 @@ void async_reply_socket::pull_socket_callback(socket_receive_pollset* unused,
     rc = data.send(z_socket);
 
     if (rc != 0) {
-      std::cerr << "Failed to send message: " << zmq_strerror(rc) << std::endl;
+      logstream(LOG_ERROR) << "Failed to send message: " << zmq_strerror(rc) << std::endl;
     }
   }
 }
@@ -265,7 +266,7 @@ void async_reply_socket::process_job(thread_data* data, zmq_msg_vector* msg) {
 
   // bad packet
   if (msg->size() == 0) {
-    std::cerr << "Unexpected Message Format\n";
+    logstream(LOG_ERROR) << "Unexpected Message Format" << std::endl;
     delete msg;
     return;
   }
@@ -274,7 +275,8 @@ void async_reply_socket::process_job(thread_data* data, zmq_msg_vector* msg) {
   if (zk_keyval) {
     std::string s = msg->extract_front();
     if(registered_keys.count(s) == 0) {
-      std::cerr << "Received message "<< s << " destined for a different object!\n";
+      logstream(LOG_ERROR) << "Received message "<< s 
+                           << " destined for a different object!" << std::endl;
       delete msg;
       return;
     }
@@ -295,7 +297,8 @@ void async_reply_socket::process_job(thread_data* data, zmq_msg_vector* msg) {
     rc = send.send(data->inproc_push_socket);
 
     if (rc != 0) {
-      std::cerr << "Failed to push message: " << zmq_strerror(rc) << std::endl;
+      logstream(LOG_ERROR) << "Failed to push message: " << zmq_strerror(rc) 
+                           << std::endl;
     }
   }
 }

--- a/oss_src/fault/sockets/async_reply_socket.cpp
+++ b/oss_src/fault/sockets/async_reply_socket.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
+#include <parallel/atomic.hpp>
 #include <boost/bind.hpp>
 #include <fault/sockets/socket_errors.hpp>
 #include <fault/sockets/socket_config.hpp>
@@ -23,7 +24,7 @@
 #endif
 namespace libfault {
 
-static size_t ASYNC_REPLY_SOCKET_CTR = 1;
+static graphlab::atomic<size_t> ASYNC_REPLY_SOCKET_CTR;
 
 
 async_reply_socket::async_reply_socket(void* zmq_ctx,
@@ -83,8 +84,8 @@ async_reply_socket::async_reply_socket(void* zmq_ctx,
 
   // now construct the threads and the required inproc sockets
   char inprocname[64];
-  sprintf(inprocname, "inproc://async_rep_%ld", ASYNC_REPLY_SOCKET_CTR);
-  ++ASYNC_REPLY_SOCKET_CTR;
+  size_t socket_number = ASYNC_REPLY_SOCKET_CTR.inc();
+  sprintf(inprocname, "inproc://async_rep_%ld", socket_number);
   inproc_pull_socket = zmq_socket(zmq_ctx, ZMQ_PULL);
   if (inproc_pull_socket == NULL) {
     print_zmq_error("async_reply_socket");

--- a/oss_src/fault/sockets/async_request_socket.cpp
+++ b/oss_src/fault/sockets/async_request_socket.cpp
@@ -7,6 +7,7 @@
  */
 #include <cassert>
 #include <boost/bind.hpp>
+#include <parallel/atomic.hpp>
 #include <fault/zmq/print_zmq_error.hpp>
 #include <fault/sockets/socket_errors.hpp>
 #include <fault/sockets/socket_config.hpp>
@@ -17,7 +18,7 @@
 #include <zookeeper_util/key_value.hpp>
 #endif
 
-static size_t ASYNC_SOCKET_CTR = 1;
+static graphlab::atomic<size_t> ASYNC_SOCKET_CTR;
 
 namespace libfault {
 
@@ -74,8 +75,8 @@ async_request_socket::async_request_socket(void* zmq_ctx,
   // spawn the inproc sockets.
   // need to make a unique name for the pull socket
   char inprocname[64];
-  sprintf(inprocname, "inproc://async_req_%ld", ASYNC_SOCKET_CTR);
-  ++ASYNC_SOCKET_CTR;
+  size_t socket_number = ASYNC_SOCKET_CTR.inc();
+  sprintf(inprocname, "inproc://async_req_%ld", socket_number);
 
   inproc_pull_socket = zmq_socket(zmq_ctx, ZMQ_PULL);
   if (inproc_pull_socket == NULL) {

--- a/oss_src/fault/sockets/async_request_socket.cpp
+++ b/oss_src/fault/sockets/async_request_socket.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <boost/bind.hpp>
 #include <parallel/atomic.hpp>
+#include <logger/logger.hpp>
 #include <fault/zmq/print_zmq_error.hpp>
 #include <fault/sockets/socket_errors.hpp>
 #include <fault/sockets/socket_config.hpp>
@@ -38,8 +39,8 @@ async_request_socket::async_request_socket(void* zmq_ctx,
   // Is at least one encryption key non-empty AND are they all not non-empty?
   if((!public_key.empty() || !secret_key.empty() || !server_public_key.empty())
      && !(!public_key.empty() && !secret_key.empty() && !server_public_key.empty())) {
-    std::cerr << "Unable to encrypt socket communication. At least one, but not all, of the "
-      "following parameters were set: public_key secret_key server_public_key";
+    logstream(LOG_ERROR) << "Unable to encrypt socket communication. At least one, but not all, of the "
+      "following parameters were set: public_key secret_key server_public_key" << std::endl;
   }
 
   z_ctx = zmq_ctx;
@@ -285,8 +286,8 @@ void* async_request_socket::get_socket(const size_t id) {
     int rc = zmq_connect(targets[id].z_socket, real_address.c_str());
     if (rc) {
       // unable to connect. Close the socket and fail
-      std::cerr << "async_request_socket error: Unable to connect to " << real_address
-                << ". Error(" << zmq_errno() << ") = " << zmq_strerror(zmq_errno()) << "\n";
+      logstream(LOG_ERROR) << "async_request_socket error: Unable to connect to " << real_address
+                << ". Error(" << zmq_errno() << ") = " << zmq_strerror(zmq_errno()) << std::endl;
       zmq_close(targets[id].z_socket);
       return NULL;
     }
@@ -350,7 +351,7 @@ async_request_socket::send_to_target(size_t id,
   push_lock.lock();
   int rc = msgs.send(inproc_push_socket);
   if (rc != 0) {
-    std::cerr << "Failed to send message: " << zmq_strerror(rc) << std::endl;
+    logstream(LOG_ERROR) << "Failed to send message: " << zmq_strerror(rc) << std::endl;
   }
   push_lock.unlock();
 

--- a/oss_src/fault/sockets/reply_socket.cpp
+++ b/oss_src/fault/sockets/reply_socket.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <boost/bind.hpp>
+#include <logger/logger.hpp>
 #include <fault/sockets/socket_errors.hpp>
 #include <fault/sockets/socket_config.hpp>
 #include <fault/sockets/reply_socket.hpp>
@@ -134,7 +135,7 @@ void reply_socket::wrapped_callback(socket_receive_pollset* unused,
 
     // bad packet
     if (recv.size() == 0) {
-      std::cerr << "Unexpected Message Format\n";
+      logstream(LOG_ERROR) << "Unexpected Message Format" << std::endl;
       continue;
     }
 
@@ -142,7 +143,7 @@ void reply_socket::wrapped_callback(socket_receive_pollset* unused,
     if (zk_keyval) {
       std::string s = recv.extract_front();
       if(registered_keys.count(s) == 0) {
-        std::cerr << "Received message "<< s << " destined for a different object!\n";
+        logstream(LOG_ERROR) << "Received message "<< s << " destined for a different object!" << std::endl;
         continue;
       }
     }

--- a/oss_src/fault/sockets/request_socket.cpp
+++ b/oss_src/fault/sockets/request_socket.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <thread>
 #include <chrono>
+#include <logger/logger.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
 #include <fault/sockets/socket_errors.hpp>
@@ -165,8 +166,8 @@ void* request_socket::get_socket(const size_t id) {
     int rc = zmq_connect(targets[id].z_socket, real_address.c_str());
     if (rc) {
       // unable to connect. Close the socket and fail
-      std::cerr << "request_socket error: Unable to connect to " << real_address
-                << ". Error(" << zmq_errno() << ") = " << zmq_strerror(zmq_errno()) << "\n";
+      logstream(LOG_ERROR) << "request_socket error: Unable to connect to " << real_address
+                << ". Error(" << zmq_errno() << ") = " << zmq_strerror(zmq_errno()) << std::endl;
       zmq_close(targets[id].z_socket);
       return NULL;
     }
@@ -222,7 +223,8 @@ int request_socket::send_and_retry(size_t id, size_t max_retry,
   size_t failure_counter = 0;
   
   if (msgs.size() == 0) {
-    std::cerr<< "request socket error: Attempting to send 0 length message\n";
+    logstream(LOG_ERROR) << "request socket error: Attempting to send 0 length message" 
+                         << std::endl;
     assert(msgs.size() > 0);
   } 
 

--- a/oss_src/fault/zmq/print_zmq_error.cpp
+++ b/oss_src/fault/zmq/print_zmq_error.cpp
@@ -6,12 +6,13 @@
  * of the BSD license. See the LICENSE file for details.
  */
 #include <fault/zmq/print_zmq_error.hpp>
+#include <logger/logger.hpp>
 #include <iostream>
 namespace libfault {
 
 void print_zmq_error(const char* prefix) {
-  std::cerr << prefix << ": Unexpected socket error(" << zmq_errno() 
-            << ") = " << zmq_strerror(zmq_errno()) << "\n";
+  logstream(LOG_ERROR) << prefix << ": Unexpected socket error(" << zmq_errno() 
+            << ") = " << zmq_strerror(zmq_errno()) << std::endl;
 }
 
 }

--- a/oss_src/lambda/worker_pool.hpp
+++ b/oss_src/lambda/worker_pool.hpp
@@ -40,8 +40,7 @@ struct worker_process {
   // next avaiable worker id 
   static int get_next_id() {
     static atomic<int> next_id;
-    next_id++;
-    return next_id;
+    return next_id.inc_ret_last();
   }
 
   // constructor
@@ -120,6 +119,8 @@ std::unique_ptr<worker_process<ProxyType>> spawn_worker(std::vector<std::string>
     } catch (std::string error) {
       logstream(LOG_ERROR) << error << std::endl;
       break;
+    } catch (const std::exception& e) {
+      logstream(LOG_ERROR) << "Error Starting cppipc client at " << worker_address << ". Error: \"" << e.what() << "\"\n";
     } catch (...) {
       logstream(LOG_ERROR) << "Error starting cppipc client at " << worker_address << std::endl;
       break;


### PR DESCRIPTION
 - A deep one inside of CPPIPC where sockets may get connected
 incorrectly due to races in a global integer. Switch to an atomic.

 - lambda worker ID needs to be atomically incremented correctly. This
 should have no other side effects since the ID is only printed and ever
 actually consumed anywhere.

 - Added a catch for std::exception& on worker spawn.

 - Changed a bunch of messages which goes to cerr to go to logger instead.

@hoytak @haijieg 