### PR TITLE
Slice op

### DIFF
--- a/oss_src/sframe_query_engine/operators/operator_properties.cpp
+++ b/oss_src/sframe_query_engine/operators/operator_properties.cpp
@@ -332,6 +332,31 @@ std::vector<size_t> get_parallel_slicable_codes(const pnode_ptr& n) {
   return codes; 
 }
 
+bool _is_linear_graph(const pnode_ptr& n, std::map<pnode_ptr, bool>& memo) {
+  if (memo.count(n)) {
+    return memo[n];
+  }
+  bool ret = true;
+  if (!is_linear_transform(n) && !is_source_node(n)) {
+    ret = false;
+  } else {
+    for (const auto& input: n->inputs) {
+      if (!is_linear_graph(input)) {
+        ret = false;
+        break;
+      }
+    }
+  }
+  memo[n] = ret;
+  return ret;
+}
+
+bool is_linear_graph(const pnode_ptr& n) {
+  std::map<pnode_ptr, bool> memo;
+  bool ret = _is_linear_graph(n, memo);
+  return ret;
+}
+
 /**************************************************************************/
 /*                                                                        */
 /*                           prove_equal_length                           */

--- a/oss_src/sframe_query_engine/operators/operator_properties.hpp
+++ b/oss_src/sframe_query_engine/operators/operator_properties.hpp
@@ -137,6 +137,10 @@ bool is_source_node(const std::shared_ptr<planner_node>& n);
  */
 bool is_parallel_slicable(const std::shared_ptr<planner_node>& n);
 
+/** Returns true if the graph contains only linear transformations.
+ */
+bool is_linear_graph(const std::shared_ptr<planner_node>& n);
+
 /** Returns a set of integers giving the different parallel slicable
  *  units for the inputs of a particular node. If 
  */

--- a/oss_src/sframe_query_engine/operators/operator_transformations.cpp
+++ b/oss_src/sframe_query_engine/operators/operator_transformations.cpp
@@ -56,4 +56,35 @@ pnode_ptr make_segmented_graph(pnode_ptr n, size_t segment_idx,
   return ret;
 }
 
+pnode_ptr make_sliced_graph(pnode_ptr n, size_t begin_index, size_t end_index,
+                            std::map<pnode_ptr, pnode_ptr>& memo) {
+  // only forward slice
+  ASSERT_LE(begin_index, end_index);
+
+  if (memo.count(n)) return memo[n];
+  pnode_ptr ret(new planner_node(*n));
+  if(is_source_node(n)) {
+    DASSERT_TRUE(n->operator_parameters.count("begin_index"));
+    DASSERT_TRUE(n->operator_parameters.count("end_index"));
+    size_t old_begin_index = n->operator_parameters.at("begin_index");
+    size_t old_end_index = n->operator_parameters.at("end_index");
+
+    // slice range can be recursive
+    size_t new_length = (end_index - begin_index);
+    begin_index = old_begin_index + begin_index;
+    end_index = begin_index + new_length;
+
+    // cannot slice beyond current range
+    ASSERT_LE(end_index, old_end_index);
+    ret->operator_parameters["begin_index"] = begin_index;
+    ret->operator_parameters["end_index"] = end_index;
+  } else {
+    for(size_t i = 0; i < ret->inputs.size(); ++i) {
+      ret->inputs[i] = make_sliced_graph(ret->inputs[i], begin_index, end_index, memo);
+    }
+  }
+  memo[n] = ret;
+  return ret;
+}
+
 }}

--- a/oss_src/sframe_query_engine/operators/operator_transformations.cpp
+++ b/oss_src/sframe_query_engine/operators/operator_transformations.cpp
@@ -83,6 +83,8 @@ pnode_ptr make_sliced_graph(pnode_ptr n, size_t begin_index, size_t end_index,
       ret->inputs[i] = make_sliced_graph(ret->inputs[i], begin_index, end_index, memo);
     }
   }
+  // forget any length  memoized
+  ret->any_operator_parameters.erase("__length_memo__");
   memo[n] = ret;
   return ret;
 }

--- a/oss_src/sframe_query_engine/operators/operator_transformations.hpp
+++ b/oss_src/sframe_query_engine/operators/operator_transformations.hpp
@@ -18,6 +18,25 @@ namespace graphlab { namespace query_eval {
 pnode_ptr make_segmented_graph(pnode_ptr n, size_t split_idx, size_t n_splits,
     std::map<pnode_ptr, pnode_ptr>& memo);
 
+/** Slice the node graph input with begin and end.
+ *
+ * Note:
+ * 1. only allows forward slice, i.e begin_index <= end_index
+ * 2. allows recursive slice, for example:
+ *
+ * \code
+ * n1 = make_sliced_graph(n0, 5, 10) // n1 contains row 5 to 9 of n0
+ * n2 = make_sliced_graph(n1, 1, 2) // n2 contains row 1 of n1, which is row 6 of n0
+ * \endcode
+ *
+ * 3. final slice range cannot exeeds the original graph
+ *
+ * \code
+ * n1 = make_sliced_graph(n0, 0, n0.size() +1) // throws error
+ * \endcode
+ */
+pnode_ptr make_sliced_graph(pnode_ptr n, size_t begin_index, size_t end_index,
+                            std::map<pnode_ptr, pnode_ptr>& memo);
 }}
 
 #endif /* _OPERATOR_TRANSFORMATIONS_H_ */

--- a/oss_src/sframe_query_engine/planning/planner.cpp
+++ b/oss_src/sframe_query_engine/planning/planner.cpp
@@ -51,7 +51,7 @@ static sframe execute_node_impl(pnode_ptr input_n, const materialize_options& ex
  * Executes a query plan, potentially parallelizing it if possible.
  * Also implements fast paths in the event the input node is a source node.
  */
-static sframe execute_node(pnode_ptr input_n, materialize_options exec_params) {
+static sframe execute_node(pnode_ptr input_n, const materialize_options& exec_params) {
   // fast path for SFRAME_SOURCE. If I am not streaming into
   // a callback, I can just call save
   if (exec_params.write_callback == nullptr &&

--- a/oss_src/sframe_query_engine/planning/planner.cpp
+++ b/oss_src/sframe_query_engine/planning/planner.cpp
@@ -31,7 +31,6 @@ REGISTER_GLOBAL(int64_t, SFRAME_MAX_LAZY_NODE_SIZE, true);
 static sframe execute_node_impl(pnode_ptr input_n, const materialize_options& exec_params) {
   // Either run directly, or split it up into a parallel section
   if(is_parallel_slicable(input_n) && (exec_params.num_segments != 0)) {
-
     size_t num_segments = exec_params.num_segments;
 
     std::vector<pnode_ptr> segments(num_segments);
@@ -52,7 +51,7 @@ static sframe execute_node_impl(pnode_ptr input_n, const materialize_options& ex
  * Executes a query plan, potentially parallelizing it if possible.
  * Also implements fast paths in the event the input node is a source node.
  */
-static sframe execute_node(pnode_ptr input_n, const materialize_options& exec_params) {
+static sframe execute_node(pnode_ptr input_n, materialize_options exec_params) {
   // fast path for SFRAME_SOURCE. If I am not streaming into
   // a callback, I can just call save
   if (exec_params.write_callback == nullptr &&
@@ -241,6 +240,7 @@ static pnode_ptr partial_materialize(pnode_ptr ptip,
     return partial_materialize_impl(ptip, exec_params, memo);
   }
 }
+
 sframe planner::materialize(pnode_ptr ptip, 
                             materialize_options exec_params) {
   std::lock_guard<recursive_mutex> GLOBAL_LOCK(global_query_lock);
@@ -289,13 +289,12 @@ sframe planner::materialize(pnode_ptr ptip,
 
 void planner::materialize(std::shared_ptr<planner_node> tip, 
                           write_callback_type callback,
-                          size_t num_segments) {
-  materialize_options args;
+                          size_t num_segments,
+                          materialize_options args) {
   args.num_segments = num_segments;
   args.write_callback = callback;
   materialize(tip, args);
 };
-
 
   /** If this returns true, it is recommended to go ahead and
    *  materialize the sframe operations on the fly to prevent memory
@@ -315,6 +314,25 @@ std::shared_ptr<planner_node>  planner::materialize_as_planner_node(
   sframe res = materialize(tip, exec_params);
   return op_sframe_source::make_planner_node(res);
 }
+
+/**
+ * Materialize the output, returning the result as a planner node.
+ */
+std::shared_ptr<planner_node> planner::slice(
+    std::shared_ptr<planner_node>& tip, size_t begin, size_t end) {
+  std::map<pnode_ptr, pnode_ptr> memo;
+  if (!is_linear_graph(tip)) {
+    // Try partial materialize first
+    materialize_options exec_params;
+    tip = partial_materialize(tip, exec_params);
+    if (!is_linear_graph(tip)) {
+      tip = materialize_as_planner_node(tip);
+    }
+  }
+  ASSERT_TRUE(is_linear_graph(tip));
+  return make_sliced_graph(tip, begin, end, memo);
+}
+
 
 bool planner::test_equal_length(std::shared_ptr<planner_node> a,
                                 std::shared_ptr<planner_node> b) {

--- a/oss_src/sframe_query_engine/planning/planner.hpp
+++ b/oss_src/sframe_query_engine/planning/planner.hpp
@@ -62,7 +62,8 @@ class planner {
    */
   void materialize(std::shared_ptr<planner_node> tip,
                    write_callback_type callback,
-                   size_t num_segments);
+                   size_t num_segments,
+                   materialize_options exec_params = materialize_options());
 
   
   /** If this returns true, it is recommended to go ahead and
@@ -77,8 +78,14 @@ class planner {
   std::shared_ptr<planner_node>  materialize_as_planner_node(
       std::shared_ptr<planner_node> tip, 
       materialize_options exec_params = materialize_options());
-  
-  
+
+  /**
+   * Returns a new planner node which is a range slice of the input node.
+   *
+   * The operation may modify (materialize) input node.
+   */
+  std::shared_ptr<planner_node> slice(std::shared_ptr<planner_node>& tip, size_t begin, size_t end);
+
   /**
    * Try to test that both a and b have equal length and to materialize
    * them if necessary to prove that this is the case.

--- a/oss_src/unity/extensions/additional_sframe_utilities.cpp
+++ b/oss_src/unity/extensions/additional_sframe_utilities.cpp
@@ -7,6 +7,7 @@
  */
 #include <string>
 #include <vector>
+#include <parallel/pthread_tools.hpp>
 #include <unity/lib/gl_sarray.hpp>
 #include <unity/lib/gl_sframe.hpp>
 #include <unity/lib/toolkit_function_macros.hpp>
@@ -18,28 +19,59 @@ typedef int(*sframe_callback_type)(const graphlab::flexible_type*, size_t, void*
 
 void sarray_callback(graphlab::gl_sarray input, size_t callback_addr, size_t callback_data_addr,
                      size_t begin, size_t end) {
+  gl_sarray sliced_input = input[{(int64_t)begin, (int64_t)end}];
+
+  // materialize in parallel to rows_by_segment_id
+  size_t nthreads = thread::cpu_count();
+  std::vector<std::vector<std::vector<flexible_type>>> rows_by_segment_id;
+  rows_by_segment_id.resize(nthreads);
+  auto copy_out_callback = [&](size_t segment_id,
+                               const std::shared_ptr<sframe_rows>& data) {
+    for (auto& row: (*data)) {
+      rows_by_segment_id[segment_id].push_back(row);
+    }
+    return false;
+  };
+  sliced_input.materialize_to_callback(copy_out_callback, nthreads);
+
+  // invoke external callback on materialized rows
   sarray_callback_type callback_fun = (sarray_callback_type)(callback_addr);
-  auto ra = input.range_iterator(begin, end);
-  auto iter = ra.begin();
-  while (iter != ra.end()) {
-    int retcode = callback_fun(&(*iter), (void*)(callback_data_addr));
-    if (retcode != 0) log_and_throw("Error applying callback. Error code " + std::to_string(retcode));
-    ++iter;
+  for (auto& rows: rows_by_segment_id) {
+    for (auto& row: rows) {
+      int retcode = callback_fun(&(row[0]), (void*)(callback_data_addr));
+      if (retcode != 0) log_and_throw("Error applying callback. Error code " + std::to_string(retcode));
+    }
   }
+
 }
 
 void sframe_callback(graphlab::gl_sframe input, size_t callback_addr, size_t callback_data_addr,
                      size_t begin, size_t end) {
   ASSERT_MSG(input.num_columns() > 0, "SFrame has no column");
+
+  // slice input
+  gl_sframe sliced_input = input[{(int64_t)begin, (int64_t)end}];
+
+  // materialize in parallel to rows_by_segment_id
+  size_t nthreads = thread::cpu_count();
+  std::vector<std::vector<std::vector<flexible_type>>> rows_by_segment_id;
+  rows_by_segment_id.resize(nthreads);
+  auto copy_out_callback = [&](size_t segment_id,
+                               const std::shared_ptr<sframe_rows>& data) {
+    for (auto& row: (*data)) {
+      rows_by_segment_id[segment_id].push_back(row);
+    }
+    return false;
+  };
+  sliced_input.materialize_to_callback(copy_out_callback, nthreads);
+
+  // invoke external callback on materialized rows
   sframe_callback_type callback_fun = (sframe_callback_type)(callback_addr);
-  auto ra = input.range_iterator(begin, end);
-  std::vector<flexible_type> row_vec;
-  auto iter = ra.begin();
-  while (iter != ra.end()) {
-    row_vec = (*iter);
-    int retcode = callback_fun(&(row_vec[0]), row_vec.size(), (void*)(callback_data_addr));
-    if (retcode != 0) log_and_throw("Error applying callback. Error code " + std::to_string(retcode));
-    ++iter;
+  for (auto& rows: rows_by_segment_id) {
+    for (auto& row: rows) {
+      int retcode = callback_fun(&(row[0]), row.size(), (void*)(callback_data_addr));
+      if (retcode != 0) log_and_throw("Error applying callback. Error code " + std::to_string(retcode));
+    }
   }
 }
 

--- a/oss_test/sframe_query_engine/basic_end_to_end.cxx
+++ b/oss_test/sframe_query_engine/basic_end_to_end.cxx
@@ -159,8 +159,7 @@ class basic_end_to_end: public CxxTest::TestSuite {
   }
 
   void test_range_slice() {
-    // const size_t TEST_LENGTH = 128;
-    const size_t TEST_LENGTH = 100;
+    const size_t TEST_LENGTH = 1000;
     global_logger().set_log_level(LOG_INFO);
 
     std::vector<flexible_type> data;


### PR DESCRIPTION
## Add slice opteration to sframe query planner
The slice operation can be directly applied to linear query plan,
or it will materialize (modifies) the existing query plan first.

Also add some utility function:
- is_linear_graph checks whether a query plan is linear
- make_sliced_graph slices the source node of a linear plan

## Make unity_sframe/unity_sarray::copy_range() more lazy
When step is 1, copy_range() will only sliced the query plan
instead of materializing. This affects all operations that
use copy_range(), e.g. and tail(), operator[], and make them much
faster.

- Fix the planner slice function to drop memoized length info.
- Change sframe callback implemenetation to use slice oeprator.