### PR TITLE
Fixes a windows compilation issue

### DIFF
--- a/oss_src/fault/sockets/socket_config.cpp
+++ b/oss_src/fault/sockets/socket_config.cpp
@@ -11,8 +11,12 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/integer_traits.hpp>
 #include <util/md5.hpp>
+
+
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
+#endif
 
 namespace libfault {
 int SEND_TIMEOUT = 3000; 


### PR DESCRIPTION
sys/socket.h and sys/un.h are Linux/Mac only headers.