### PR TITLE
Fixes resource leak when saving sframes

### DIFF
--- a/oss_src/sframe/sarray_saving.hpp
+++ b/oss_src/sframe/sarray_saving.hpp
@@ -73,6 +73,7 @@ void sarray_save_blockwise(const sarray<T>& cur_column,
       advance_column_blocks_to_next_block(block_manager, col);
       // if there are still blocks. push it back 
     }
+    block_manager.close_column(col.segment_address);
 
     // close writers.
     writer.close_segment(0);

--- a/oss_src/sframe/sframe_saving.cpp
+++ b/oss_src/sframe/sframe_saving.cpp
@@ -192,6 +192,12 @@ void sframe_save_blockwise(const sframe& sf_source,
       frame_index.column_files.push_back(col.index_file);
     }
     write_sframe_index_file(index_file, frame_index);
+    // cleanup and close. I wish C++ has finally
+    for(auto& col: cols) {
+      try {
+        block_manager.close_column(col.segment_address);
+      } catch (...) { }
+    }
   } catch (...) {
     // cleanup. close any open columns
     for(auto& col: cols) {


### PR DESCRIPTION
Remember to close columns after opening them.