### PR TITLE
Loading environment variables from a config file

### DIFF
--- a/oss_src/unity/python/sframe/__init__.py
+++ b/oss_src/unity/python/sframe/__init__.py
@@ -21,7 +21,7 @@ of the BSD license. See the LICENSE file for details.
 '''
 
 # Important to call this before everything else
-import sys_util as _sys_util
+import .sys_util as _sys_util
 _sys_util.setup_environment_from_config_file()
 
 

--- a/oss_src/unity/python/sframe/__init__.py
+++ b/oss_src/unity/python/sframe/__init__.py
@@ -21,8 +21,10 @@ of the BSD license. See the LICENSE file for details.
 '''
 
 # Important to call this before everything else
-import .sys_util as _sys_util
-_sys_util.setup_environment_from_config_file()
+from .sys_util import setup_environment_from_config_file \
+     as _setup_environment_from_config_file
+     
+_setup_environment_from_config_file()
 
 
 from . import util

--- a/oss_src/unity/python/sframe/__init__.py
+++ b/oss_src/unity/python/sframe/__init__.py
@@ -20,6 +20,11 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 '''
 
+# Important to call this before everything else
+import sys_util as _sys_util
+_sys_util.setup_environment_from_config_file()
+
+
 from . import util
 from .util import set_runtime_config
 from .util import get_runtime_config

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -495,22 +495,25 @@ def setup_environment_from_config_file():
 
     if not exists(config_file):
         return
-    
-    config = _ConfigParser.SafeConfigParser()
-    config.read(config_file)
 
-    __section = "Environment"
-    
-    if config.has_section(__section):
-        items = config.items(__section)
+    try:
+        config = _ConfigParser.SafeConfigParser()
+        config.read(config_file)
 
-        for k, v in items:
-            try:
-                os.environ[k.upper()] = v
-            except Exception as e:
-                print(("WARNING: Error setting environment variable "
-                       "'%s = %s' from config file '%s': %s.")
-                      % (k, str(v), config_file, str(e)) )
+        __section = "Environment"
+
+        if config.has_section(__section):
+            items = config.items(__section)
+
+            for k, v in items:
+                try:
+                    os.environ[k.upper()] = v
+                except Exception as e:
+                    print(("WARNING: Error setting environment variable "
+                           "'%s = %s' from config file '%s': %s.")
+                          % (k, str(v), config_file, str(e)) )
+    except Exception as e:
+        print "WARNING: Error reading config file '%s': %s." % (config_file, str(e))
                       
 
 def write_config_file_value(key, value):

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -513,7 +513,7 @@ def setup_environment_from_config_file():
                            "'%s = %s' from config file '%s': %s.")
                           % (k, str(v), config_file, str(e)) )
     except Exception as e:
-        print "WARNING: Error reading config file '%s': %s." % (config_file, str(e))
+        print("WARNING: Error reading config file '%s': %s." % (config_file, str(e)))
                       
 
 def write_config_file_value(key, value):

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -448,7 +448,7 @@ def get_library_name():
     Returns either sframe or graphlab depending on which library
     this file is bundled with.
     """
-    from os.path import split, abspath, expanduser, join
+    from os.path import split, abspath
     
     __lib_name = split(split(abspath(sys.modules[__name__].__file__))[0])[1]
 
@@ -463,7 +463,7 @@ def get_config_file():
     variables are written.
     """
     import os
-    from os.path import split, abspath, expanduser, join, exists
+    from os.path import abspath, expanduser, join, exists
 
     __lib_name = get_library_name()
 

--- a/oss_src/unity/python/sframe/sys_util.py
+++ b/oss_src/unity/python/sframe/sys_util.py
@@ -15,6 +15,10 @@ import subprocess as _subprocess
 from ._scripts import _pylambda_worker
 from copy import copy
 
+if sys.version_info.major == 2:
+    import ConfigParser as _ConfigParser
+else:
+    import configparser as _ConfigParser
 
 def make_unity_server_env():
     """
@@ -166,7 +170,6 @@ def test_pylambda_worker():
     proc.wait()
 
     ################################################################################
-
 
     # Write out the current system path.
     open(join(temp_dir, "sys_path_1.log"), "w").write(
@@ -439,3 +442,98 @@ def _get_expanded_classpath(classpath):
                     for path in classpath.split(os.path.pathsep))
     logging.getLogger(__name__).debug('classpath being used: %s' % jars)
     return jars
+
+def get_library_name():
+    """
+    Returns either sframe or graphlab depending on which library
+    this file is bundled with.
+    """
+    from os.path import split, abspath, expanduser, join
+    
+    __lib_name = split(split(abspath(sys.modules[__name__].__file__))[0])[1]
+
+    assert __lib_name in ["sframe", "graphlab"]
+
+    return __lib_name
+
+
+def get_config_file():
+    """
+    Returns the file name of the config file from which the environment
+    variables are written.
+    """
+    import os
+    from os.path import split, abspath, expanduser, join, exists
+
+    __lib_name = get_library_name()
+
+    assert __lib_name in ["sframe", "graphlab"]
+
+    __default_config_path = join(expanduser("~"), ".%s" % __lib_name, "config")
+
+    if "GRAPHLAB_CONFIG_FILE" in os.environ:
+        __default_config_path = abspath(expanduser(os.environ["GRAPHLAB_CONFIG_FILE"]))
+
+        if not exists(__default_config_path):
+            print(("WARNING: Config file specified in environment variable "
+                   "'GRAPHLAB_CONFIG_FILE' as "
+                   "'%s', but this path does not exist.") % __default_config_path)
+
+    return __default_config_path
+
+
+def setup_environment_from_config_file():
+    """
+    Imports the environmental configuration settings from the
+    config file, if present, and sets the environment
+    variables to test it.
+    """
+
+    from os.path import exists
+    
+    config_file = get_config_file()
+
+    if not exists(config_file):
+        return
+    
+    config = _ConfigParser.SafeConfigParser()
+    config.read(config_file)
+
+    __section = "Environment"
+    
+    if config.has_section(__section):
+        items = config.items(__section)
+
+        for k, v in items:
+            try:
+                os.environ[k.upper()] = v
+            except Exception as e:
+                print(("WARNING: Error setting environment variable "
+                       "'%s = %s' from config file '%s': %s.")
+                      % (k, str(v), config_file, str(e)) )
+                      
+
+def write_config_file_value(key, value):
+    """
+    Writes an environment variable configuration to the current
+    config file.  This will be read in on the next restart.
+    The config file is created if not present.
+
+    Note: The variables will not take effect until after restart.
+    """
+
+    filename = get_config_file()
+
+    config = _ConfigParser.SafeConfigParser()
+    config.read(filename)
+
+    __section = "Environment"
+    
+    if not(config.has_section(__section)):
+        config.add_section(__section)
+        
+    config.set(__section, key, value)
+
+    with open(filename, 'w') as config_file:
+        config.write(config_file)
+    

--- a/oss_src/unity/python/sframe/test/test_environment_config.py
+++ b/oss_src/unity/python/sframe/test/test_environment_config.py
@@ -71,7 +71,8 @@ else:
 
         run_file = join(test_dir, "run_test.py")
 
-        open(run_file, 'w').write(run_script)
+        with open(run_file, 'w') as f:
+            f.write(run_script)
 
         env = make_unity_server_env()
         env["GRAPHLAB_CONFIG_FILE"] = config_file

--- a/oss_src/unity/python/sframe/test/test_environment_config.py
+++ b/oss_src/unity/python/sframe/test/test_environment_config.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+'''
+Copyright (C) 2016 Dato, Inc.
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+'''
+from __future__ import print_function
+
+from ..sys_util import get_config_file
+from ..sys_util import setup_environment_from_config_file
+from ..sys_util import write_config_file_value
+from ..sys_util import get_library_name
+from ..sys_util import make_unity_server_env
+
+import unittest
+import tempfile
+import subprocess
+import sys
+
+from os.path import join
+import os
+import shutil
+
+class EnvironmentConfigTester(unittest.TestCase):
+
+
+    def test_config_basic_write(self):
+
+        test_dir = tempfile.mkdtemp()
+        config_file = join(test_dir, "test_config")
+        os.environ["GRAPHLAB_CONFIG_FILE"] = config_file
+
+        try:
+            self.assertEqual(get_config_file(), config_file)
+            write_config_file_value("GRAPHLAB_FILE_TEST_VALUE", "this-is-a-test")
+            setup_environment_from_config_file()
+            self.assertEqual(os.environ["GRAPHLAB_FILE_TEST_VALUE"], "this-is-a-test")
+        finally:
+            shutil.rmtree(test_dir)
+            del os.environ["GRAPHLAB_CONFIG_FILE"]
+
+    def test_environment_import(self):
+
+        test_dir = tempfile.mkdtemp()
+        config_file = join(test_dir, "test_config")
+
+        os.environ["GRAPHLAB_CONFIG_FILE"] = config_file
+        write_config_file_value("GRAPHLAB_FILEIO_MAXIMUM_CACHE_CAPACITY", "123456")
+
+        run_script = r"""
+import sys
+import os
+
+system_path = os.environ.get("__GL_SYS_PATH__", "")
+del sys.path[:]
+sys.path.extend(p.strip() for p in system_path.split(os.pathsep) if p.strip())
+
+import %(library)s
+
+var = %(library)s.get_runtime_config()["GRAPHLAB_FILEIO_MAXIMUM_CACHE_CAPACITY"]
+
+if var == 123456:
+    sys.exit(0)
+else:
+    print("boo: GRAPHLAB_FILEIO_MAXIMUM_CACHE_CAPACITY = ", var, "and this is wrong.  Seriously.")
+    sys.exit(1)
+    
+""" % {"library" : get_library_name()}
+
+        run_file = join(test_dir, "run_test.py")
+
+        open(run_file, 'w').write(run_script)
+
+        env = make_unity_server_env()
+        env["GRAPHLAB_CONFIG_FILE"] = config_file
+
+        ret_code = subprocess.call([sys.executable, run_file], env = env)
+
+        self.assertEqual(ret_code, 0)
+        


### PR DESCRIPTION
This PR allows the user to permanently write environment variables to
a common config file, then have those values be persistent across
sessions.

Use sys_util.get_config_file() to return the name of this config file.
Use sys_util.write_config_file_value(k, v) to write a value to this config file.