### PR TITLE
Ternary operator

### DIFF
--- a/oss_src/sframe_query_engine/operators/all_operators.hpp
+++ b/oss_src/sframe_query_engine/operators/all_operators.hpp
@@ -23,6 +23,7 @@
 #include <sframe_query_engine/operators/reduce.hpp>
 #include <sframe_query_engine/operators/lambda_transform.hpp>
 #include <sframe_query_engine/operators/optonly_identity_operator.hpp>
+#include <sframe_query_engine/operators/ternary_operator.hpp>
 
 
 #endif /* GRAPHLAB_SFRAME_QUERY_ALL_OPERATORS_H_ */

--- a/oss_src/sframe_query_engine/operators/operator_properties.cpp
+++ b/oss_src/sframe_query_engine/operators/operator_properties.cpp
@@ -50,6 +50,8 @@ RetType extract_field(planner_node_type ptype, CallArgs... call_args) {
       return FieldExtractionVisitor<planner_node_type::REDUCE_NODE>::get(call_args...);
     case planner_node_type::GENERALIZED_UNION_PROJECT_NODE:
       return FieldExtractionVisitor<planner_node_type::GENERALIZED_UNION_PROJECT_NODE>::get(call_args...);
+    case planner_node_type::TERNARY_OPERATOR:
+      return FieldExtractionVisitor<planner_node_type::TERNARY_OPERATOR>::get(call_args...);
     case planner_node_type::IDENTITY_NODE:
       return FieldExtractionVisitor<planner_node_type::IDENTITY_NODE>::get(call_args...);
     case planner_node_type::INVALID:

--- a/oss_src/sframe_query_engine/operators/operator_properties.hpp
+++ b/oss_src/sframe_query_engine/operators/operator_properties.hpp
@@ -38,6 +38,7 @@ enum class planner_node_type : int {
     UNION_NODE,
     GENERALIZED_UNION_PROJECT_NODE,
     REDUCE_NODE,
+    TERNARY_OPERATOR,
 
       // These are used as logical-node-only types.  Do not actually become an operator.
       IDENTITY_NODE,

--- a/oss_src/sframe_query_engine/operators/ternary_operator.hpp
+++ b/oss_src/sframe_query_engine/operators/ternary_operator.hpp
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#ifndef GRAPHLAB_SFRAME_QUERY_MANAGER_TERNARY_OPERATOR_HPP
+#define GRAPHLAB_SFRAME_QUERY_MANAGER_TERNARY_OPERATOR_HPP
+
+#include <functional>
+#include <logger/assertions.hpp>
+#include <flexible_type/flexible_type.hpp>
+#include <sframe_query_engine/operators/operator.hpp>
+#include <sframe_query_engine/execution/query_context.hpp>
+#include <sframe_query_engine/operators/operator_properties.hpp>
+
+namespace graphlab { 
+namespace query_eval {
+
+/**
+ * An element-wise "ternary operator". 
+ * Takes 3 columns: condition, istrue, isfalse.
+ * For each row, 
+ *    if condition == True, the corresponding row is selected from istrue
+ *    if condition == False, the corresponding row is selected from isfalse
+ */
+template<>
+class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator {
+ public:
+  
+  planner_node_type type() const { return planner_node_type::TERNARY_OPERATOR; } 
+
+  static std::string name() { return "binary_transform"; }
+        
+  static query_operator_attributes attributes() {
+    query_operator_attributes ret;
+    ret.attribute_bitfield = query_operator_attributes::LINEAR;
+    ret.num_inputs = 3;
+    return ret;
+  }
+  
+  inline operator_impl() { } 
+
+  inline std::shared_ptr<query_operator> clone() const {
+    return std::make_shared<operator_impl>(*this);
+  }
+  
+  inline void execute(query_context& context) {
+    constexpr size_t CONDITION_INPUT = 0;
+    constexpr size_t ISTRUE_INPUT = 1;
+    constexpr size_t ISFALSE_INPUT = 2;
+    while(1) {
+      auto condition = context.get_next(CONDITION_INPUT);
+
+      if (condition == nullptr) break;
+      ASSERT_EQ(condition->num_columns(), 1);
+      const auto& condition_column = *(condition->cget_columns()[0]);
+      // sum the number of non-zeros
+      size_t num_non_zero = std::accumulate(condition_column.begin(),
+                                            condition_column.end(),
+                                            (size_t)0,
+                                            [](size_t acc, const flexible_type& f) {
+                                              return acc + (! f.is_zero());
+                                            });
+
+      auto output_buffer = context.get_output_buffer();
+
+      // fast path. All true, or all false
+      if (num_non_zero == 0 || num_non_zero == condition_column.size()) {
+        size_t input_number;
+        size_t skip_number;
+        if (num_non_zero == 0) {
+          skip_number = ISTRUE_INPUT;
+          input_number = ISFALSE_INPUT;
+        } else {
+          skip_number = ISFALSE_INPUT;
+          input_number = ISTRUE_INPUT;
+        }
+
+        // all is false
+        context.skip_next(skip_number);
+
+        auto& out_columns = output_buffer->get_columns();
+
+        auto input = context.get_next(input_number);
+        ASSERT_EQ(input->num_rows(), condition_column.size());
+        ASSERT_EQ(input->num_columns(), 1);
+
+        out_columns.clear();
+        out_columns.push_back(input->cget_columns()[0]);
+        context.emit(output_buffer);
+      } 
+      
+      auto isfalse = context.get_next(ISFALSE_INPUT);
+      auto istrue = context.get_next(ISTRUE_INPUT);
+      ASSERT_TRUE(istrue != nullptr && isfalse != nullptr);
+      ASSERT_EQ(isfalse->num_rows(), condition_column.size());
+      ASSERT_EQ(istrue->num_rows(), condition_column.size());
+      ASSERT_EQ(isfalse->num_columns(), 1);
+      ASSERT_EQ(istrue->num_columns(), 1);
+
+      output_buffer->resize(1, condition_column.size());
+
+      auto istrue_iter = istrue->cbegin();
+      auto isfalse_iter = isfalse->cbegin();
+      auto out_iter = output_buffer->begin();
+      for (auto& cval : condition_column) {
+        if (cval.is_zero()) {
+            (*out_iter)[0] = (*isfalse_iter)[0];
+        } else {
+            (*out_iter)[0] = (*istrue_iter)[0];
+        }
+        ++istrue_iter;
+        ++isfalse_iter;
+        ++out_iter;
+      }
+      context.emit(output_buffer);
+    }
+  }
+
+  static std::shared_ptr<planner_node> make_planner_node(
+      std::shared_ptr<planner_node> condition,
+      std::shared_ptr<planner_node> istrue,
+      std::shared_ptr<planner_node> isfalse) {
+    
+    return planner_node::make_shared(planner_node_type::TERNARY_OPERATOR, 
+                                     {},
+                                     {},
+                                     {condition, istrue, isfalse});
+  }
+
+  static std::shared_ptr<query_operator> from_planner_node(
+      std::shared_ptr<planner_node> pnode) {
+    
+    ASSERT_EQ((int)pnode->operator_type, (int)planner_node_type::TERNARY_OPERATOR);
+    ASSERT_EQ(pnode->inputs.size(), 3);
+
+    return std::make_shared<operator_impl>();
+  }
+
+  static std::vector<flex_type_enum> infer_type(std::shared_ptr<planner_node> pnode) {
+    ASSERT_EQ((int)pnode->operator_type, (int)planner_node_type::TERNARY_OPERATOR);
+    return infer_planner_node_type(pnode->inputs[0]);
+  }
+
+  static int64_t infer_length(std::shared_ptr<planner_node> pnode) {
+    ASSERT_EQ((int)pnode->operator_type, (int)planner_node_type::TERNARY_OPERATOR);
+    return infer_planner_node_length(pnode->inputs[0]);
+  }
+  
+};
+
+typedef operator_impl<planner_node_type::TERNARY_OPERATOR> op_ternary_operator;
+
+
+} // query_eval
+} // graphlab
+
+#endif // GRAPHLAB_SFRAME_QUERY_MANAGER_TERNARY_OPERATOR_HPP

--- a/oss_src/sframe_query_engine/operators/ternary_operator.hpp
+++ b/oss_src/sframe_query_engine/operators/ternary_operator.hpp
@@ -127,8 +127,8 @@ class operator_impl<planner_node_type::TERNARY_OPERATOR> : public query_operator
       std::shared_ptr<planner_node> isfalse) {
     
     return planner_node::make_shared(planner_node_type::TERNARY_OPERATOR, 
-                                     {},
-                                     {},
+                                     std::map<std::string, flexible_type>(),
+                                     std::map<std::string, any>(),
                                      {condition, istrue, isfalse});
   }
 

--- a/oss_src/unity/lib/api/unity_sarray_interface.hpp
+++ b/oss_src/unity/lib/api/unity_sarray_interface.hpp
@@ -86,6 +86,8 @@ GENERATE_INTERFACE_AND_PROXY(unity_sarray_base, unity_sarray_proxy,
       (std::vector<flexible_type>, to_vector, )
       (std::shared_ptr<unity_sarray_base>, builtin_rolling_apply,(const std::string&)(ssize_t)(ssize_t)(size_t))
       (std::shared_ptr<unity_sarray_base>, builtin_cumulative_aggregate,(const std::string&))
+      (std::shared_ptr<unity_sarray_base>, ternary_operator,(std::shared_ptr<unity_sarray_base>)(std::shared_ptr<unity_sarray_base>))
+      (std::shared_ptr<unity_sarray_base>, to_const,(const flexible_type&)(flex_type_enum))
     )
 } // namespace graphlab
 #endif // GRAPHLAB_UNITY_SARRAY_INTERFACE_HPP

--- a/oss_src/unity/lib/unity_sarray.hpp
+++ b/oss_src/unity/lib/unity_sarray.hpp
@@ -646,6 +646,26 @@ class unity_sarray: public unity_sarray_base {
    */
   std::shared_ptr<unity_sarray_base> subslice(flexible_type start, flexible_type step, flexible_type stop);
 
+
+   /**
+    * is_true and is_false and this SArray must be the same size.
+    * Returns an SArray of the same size.
+    *
+    * For each non-zero value in this SArray, it picks up the corresponding value from is_true.
+    * For each zero value in this SArray, it picks up the corresponding value from is_false.
+    */
+  std::shared_ptr<unity_sarray_base> ternary_operator(std::shared_ptr<unity_sarray_base> is_true,
+                                                      std::shared_ptr<unity_sarray_base> is_false);
+
+
+  /**
+   * Returns an SArray of the same length but with all constant values. 
+   * Does so without materializing the SArray.
+   *
+   * \note This is really only useful for internal use
+   */
+  std::shared_ptr<unity_sarray_base> to_const(const flexible_type& value, flex_type_enum dtype);
+
   /**
    * Begin iteration through the SArray.
    *
@@ -701,7 +721,6 @@ class unity_sarray: public unity_sarray_base {
    * test hook to check if the array is materialized
    **/
    bool is_materialized();
-
    /**
     * Returns an integer which attempts to uniquely identifies the contents of
     * the SArray.

--- a/oss_src/unity/python/sframe/cython/cy_sarray.pxd
+++ b/oss_src/unity/python/sframe/cython/cy_sarray.pxd
@@ -86,6 +86,8 @@ cdef extern from "<unity/lib/api/unity_sarray_interface.hpp>" namespace 'graphla
         unity_sarray_base_ptr builtin_rolling_apply(string, ssize_t, ssize_t, size_t) except +
         unity_sarray_base_ptr builtin_cumulative_aggregate(string) except +
         unity_sarray_base_ptr subslice(flexible_type, flexible_type, flexible_type) except +
+        unity_sarray_base_ptr ternary_operator(unity_sarray_base_ptr, unity_sarray_base_ptr) except +
+        unity_sarray_base_ptr to_const(const flexible_type&, flex_type_enum) except +
 
 
 cdef create_proxy_wrapper_from_existing_proxy(PyCommClient cli, const unity_sarray_base_ptr& proxy)
@@ -218,3 +220,7 @@ cdef class UnitySArrayProxy:
     cpdef builtin_cumulative_aggregate(self, fn_name)
 
     cpdef subslice(self, start, step, stop)
+
+    cpdef ternary_operator(self, UnitySArrayProxy istrue, UnitySArrayProxy isfalse)
+
+    cpdef to_const(self, object value, type t)

--- a/oss_src/unity/python/sframe/cython/cy_sarray.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_sarray.pyx
@@ -12,6 +12,7 @@ from cython.operator cimport dereference as deref
 from .cy_flexible_type cimport flex_type_enum_from_pytype
 from .cy_flexible_type cimport pytype_from_flex_type_enum
 from .cy_flexible_type cimport flexible_type_from_pyobject
+from .cy_flexible_type cimport flexible_type_from_pyobject_hint
 from .cy_flexible_type cimport flex_list_from_iterable
 from .cy_flexible_type cimport flex_list_from_typed_iterable
 from .cy_flexible_type cimport common_typed_flex_list_from_iterable
@@ -87,8 +88,15 @@ cdef class UnitySArrayProxy:
             self.thisptr.construct_from_avro(url)
 
     cpdef load_from_const(self, object value, size_t size, type t):
-        cdef flexible_type val = flexible_type_from_pyobject(value)
+        cdef flexible_type val
         cdef flex_type_enum datatype = flex_type_enum_from_pytype(t)
+        # if value is None, the hinted type coercion is bad. 
+        # We do want to keep val as None
+        # If t is None or NoneType, we assume there is no hint
+        if value is None or t is None or t is type(None):
+            val = flexible_type_from_pyobject(value)
+        else:
+            val = flexible_type_from_pyobject_hint(value, t)
         with nogil:
             self.thisptr.construct_from_const(val, size, datatype)
     
@@ -476,8 +484,16 @@ cdef class UnitySArrayProxy:
         return create_proxy_wrapper_from_existing_proxy(self._cli, proxy)
 
     cpdef to_const(self, object value, type t):
-        cdef flexible_type val = flexible_type_from_pyobject(value)
+        cdef flexible_type val
         cdef flex_type_enum datatype = flex_type_enum_from_pytype(t)
+        # if value is None, the hinted type coercion is bad. 
+        # We do want to keep val as None
+        # If t is None or NoneType, we assume there is no hint
+        if value is None or t is None or t is type(None):
+            val = flexible_type_from_pyobject(value)
+        else:
+            val = flexible_type_from_pyobject_hint(value, t)
+
         cdef unity_sarray_base_ptr proxy
         with nogil:
             proxy = self.thisptr.to_const(val, datatype)

--- a/oss_src/unity/python/sframe/cython/cy_sarray.pyx
+++ b/oss_src/unity/python/sframe/cython/cy_sarray.pyx
@@ -468,3 +468,18 @@ cdef class UnitySArrayProxy:
         with nogil:
             proxy = (self.thisptr.subslice(fstart, fstep, fstop))
         return create_proxy_wrapper_from_existing_proxy(self._cli, proxy)
+
+    cpdef ternary_operator(self, UnitySArrayProxy istrue, UnitySArrayProxy isfalse):
+        cdef unity_sarray_base_ptr proxy
+        with nogil:
+            proxy = (self.thisptr.ternary_operator(istrue._base_ptr, isfalse._base_ptr))
+        return create_proxy_wrapper_from_existing_proxy(self._cli, proxy)
+
+    cpdef to_const(self, object value, type t):
+        cdef flexible_type val = flexible_type_from_pyobject(value)
+        cdef flex_type_enum datatype = flex_type_enum_from_pytype(t)
+        cdef unity_sarray_base_ptr proxy
+        with nogil:
+            proxy = self.thisptr.to_const(val, datatype)
+        return create_proxy_wrapper_from_existing_proxy(self._cli, proxy)
+

--- a/oss_src/unity/python/sframe/data_structures/sarray.py
+++ b/oss_src/unity/python/sframe/data_structures/sarray.py
@@ -559,6 +559,19 @@ class SArray(object):
         proxy.load_from_avro(filename)
         return cls(_proxy = proxy)
 
+    @classmethod
+    def where(cls, condition, istrue, isfalse):
+        true_is_sarray = isinstance(istrue, SArray)
+        false_is_sarray = isinstance(isfalse, SArray)
+        if not true_is_sarray and false_is_sarray:
+            istrue = cls(_proxy=condition.__proxy__.to_const(istrue, isfalse.dtype()))
+        if true_is_sarray and not false_is_sarray:
+            isfalse = cls(_proxy=condition.__proxy__.to_const(isfalse, istrue.dtype()))
+        if not true_is_sarray and not false_is_sarray:
+            if type(istrue) != type(isfalse):
+                raise TypeError("true and false inputs are of different types")
+        return cls(_proxy=condition.__proxy__.ternary_operator(istrue.__proxy__, isfalse.__proxy__))
+
     def to_numpy(self):
         """
         Converts this SArray to a numpy array

--- a/oss_src/unity/python/sframe/test/test_sarray.py
+++ b/oss_src/unity/python/sframe/test/test_sarray.py
@@ -1549,6 +1549,10 @@ class SArrayTest(unittest.TestCase):
         self.assertEquals(list(g), [None] * 100)
         self.assertEqual(g.dtype(), list)
 
+        g = SArray.from_const([1], 100, list)
+        self.assertEquals(list(g), [[1]] * 100)
+        self.assertEqual(g.dtype(), list)
+
     def test_from_sequence(self):
         with self.assertRaises(TypeError):
             g = SArray.from_sequence()
@@ -2738,3 +2742,53 @@ class SArrayTest(unittest.TestCase):
         self.assertFalse(sa.is_materialized())
         sa.materialize()
         self.assertTrue(sa.is_materialized())
+
+    def test_ternary(self):
+        lista = range(1000)
+        a = SArray(lista)
+
+        # identity
+        self.__test_equal(SArray.where(a > 10, a, a), lista, int)
+
+        # clip lower
+        self.__test_equal(SArray.where(a > 10, a, 10), 
+                          [i if i > 10 else 10 for i in lista], int)
+
+        # clip upper
+        self.__test_equal(SArray.where(a > 10, 10, a), 
+                          [10 if i > 10 else i for i in lista], int)
+
+        # constants
+        self.__test_equal(SArray.where(a > 10, 10, 9), 
+                          [10 if i > 10 else 9 for i in lista], int)
+
+        # constant float
+        self.__test_equal(SArray.where(a > 10, 10.0, 9.0), 
+                          [10.0 if i > 10 else 9.0 for i in lista], float)
+
+        # constant str
+        self.__test_equal(SArray.where(a > 10, "10", "9"), 
+                          ["10" if i > 10 else "9" for i in lista], str)
+
+        #inconsistent types
+        with self.assertRaises(TypeError):
+            SArray.where(a > 10, 10, "9") # 10 and "9" different types
+
+        #inconsistent types
+        with self.assertRaises(TypeError):
+            SArray.where(a > 10, a, "9") # expecting an integer for "a"
+
+        # technically different types but type coercion happened
+        self.__test_equal(SArray.where(a > 10, a, 10.0), 
+                          [i if i > 10 else 10 for i in lista], int)
+
+        # list types
+        self.__test_equal(SArray.where(a > 10, [], [1], list), 
+                          [[] if i > 10 else [1] for i in lista], list)
+
+        # really the same as the above, but using an SArray in place 
+        # of a constant in istrue. And hoping the type coercion 
+        # will take care of [1]
+        b = SArray([[] for i in range(1000)])
+        self.__test_equal(SArray.where(a > 10, b, [1]), 
+                          [[] if i > 10 else [1] for i in lista], list)

--- a/oss_test/sframe_query_engine/operators/CMakeLists.txt
+++ b/oss_test/sframe_query_engine/operators/CMakeLists.txt
@@ -8,6 +8,7 @@ make_cxxtest(append.cxx REQUIRES sframe sframe_query_engine)
 make_cxxtest(binary_transform.cxx REQUIRES sframe sframe_query_engine)
 make_cxxtest(logical_filter.cxx REQUIRES sframe sframe_query_engine)
 make_cxxtest(union.cxx REQUIRES sframe sframe_query_engine)
+make_cxxtest(ternary_operator.cxx REQUIRES sframe sframe_query_engine)
 
 # The lambda test requires a pickled function without graphlab dependency
 # make_cxxtest(lambda_transform.cxx REQUIRES sframe sframe_query_engine)

--- a/oss_test/sframe_query_engine/operators/ternary_operator.cxx
+++ b/oss_test/sframe_query_engine/operators/ternary_operator.cxx
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 Dato, Inc.
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+#include <sframe_query_engine/execution/execution_node.hpp>
+#include <sframe_query_engine/operators/sarray_source.hpp>
+#include <sframe_query_engine/operators/ternary_operator.hpp>
+#include <sframe/sarray.hpp>
+#include <sframe/algorithm.hpp>
+#include <cxxtest/TestSuite.h>
+
+#include "check_node.hpp"
+
+using namespace graphlab;
+using namespace graphlab::query_eval;
+
+class ternary_operator_test: public CxxTest::TestSuite {
+ public:
+  void test_ternary() {
+    std::vector<flexible_type> condition{0,1,0,1,0};
+    std::vector<flexible_type> istrue{2,2,2,2,2};
+    std::vector<flexible_type> isfalse{0,0,0,0,0};
+
+    auto sa_condition = std::make_shared<sarray<flexible_type>>();
+    sa_condition->open_for_write();
+    graphlab::copy(condition.begin(), condition.end(), *sa_condition);
+    sa_condition->close();
+
+    auto sa_true = std::make_shared<sarray<flexible_type>>();
+    sa_true->open_for_write();
+    graphlab::copy(istrue.begin(), istrue.end(), *sa_true);
+    sa_true->close();
+
+    auto sa_false = std::make_shared<sarray<flexible_type>>();
+    sa_false->open_for_write();
+    graphlab::copy(isfalse.begin(), isfalse.end(), *sa_false);
+    sa_false->close();
+
+    std::vector<flexible_type> expected{0,2,0,2,0};
+    auto node = make_node(op_sarray_source(sa_condition),
+                          op_sarray_source(sa_true), 
+                          op_sarray_source(sa_false));
+    check_node(node, expected);
+  }
+
+ private:
+  std::shared_ptr<execution_node> make_node(const op_sarray_source& condition,
+                                            const op_sarray_source& source_true,
+                                            const op_sarray_source& source_false) {
+    auto condition_node = std::make_shared<execution_node>(std::make_shared<op_sarray_source>(condition));
+    auto true_node = std::make_shared<execution_node>(std::make_shared<op_sarray_source>(source_true));
+    auto false_node = std::make_shared<execution_node>(std::make_shared<op_sarray_source>(source_false));
+    auto node = std::make_shared<execution_node>(std::make_shared<op_ternary_operator>(),
+                             std::vector<std::shared_ptr<execution_node>>({condition_node, true_node, false_node}));
+    return node;
+  }
+};


### PR DESCRIPTION
Implements a ternary operator. A little like np.where. Extremely useful for replacing values in an SArray.

```
Returns an SArray with the same values as g with values above 10
clipped to 10

>>> g = SArray([6,7,8,9,10,11,12,13])
>>> SArray.where(g > 10, 10, g)
dtype: int
Rows: 8
[6, 7, 8, 9, 10, 10, 10, 10]

Returns an SArray with the same values as g with values below 10
clipped to 10

>>> SArray.where(g > 10, g, 10)
dtype: int
Rows: 8
[10, 10, 10, 10, 10, 11, 12, 13]

Returns an SArray with the same values of g with all values == 1
replaced by None

>>> g = SArray([1,2,3,4,1,2,3,4])
>>> SArray.where(g == 1, None, g)
dtype: int
Rows: 8
[None, 2, 3, 4, None, 2, 3, 4]
```

Also fixes a bunch of oddities with SArray.from_const.
Previously,
```
gl.SArray.from_const([1], 10, list)
```
will produce an SArray of
[[1.0],[1.0],[1.0],[1.0],[1.0]...]
converting each of the integers to a float.

Now it does the right thing.