### PR TITLE
Robustification of lambda worker startup code.

### DIFF
--- a/oss_src/lambda/CMakeLists.txt
+++ b/oss_src/lambda/CMakeLists.txt
@@ -2,6 +2,7 @@ project(lambda)
 
 make_library(pylambda
   SOURCES
+    worker_pool.cpp
     lambda_constants.cpp
     lambda_master.cpp
     pylambda_function.cpp

--- a/oss_src/lambda/worker_pool.cpp
+++ b/oss_src/lambda/worker_pool.cpp
@@ -1,0 +1,16 @@
+#include <globals/globals.hpp>
+#include <export.hpp>
+
+namespace graphlab {
+
+/** The timeout for connecting to a lambda worker, in seconds. 
+ *
+ *  Set to 0 to attempt one try and exit immediately on failure. 
+ *
+ *  Set to -1 to disable timeout completely. 
+ */
+EXPORT double LAMBDA_WORKER_CONNECTION_TIMEOUT = 60;
+
+REGISTER_GLOBAL(double, LAMBDA_WORKER_CONNECTION_TIMEOUT, true)
+
+}


### PR DESCRIPTION
Makes the starting code to the lambda worker process more robust. 

env variable GRAPHLAB_LAMBDA_WORKER_CONNECTION_TIMEOUT now controls the timeout. Default is 60 seconds.  Setting to 0 means there is one try.  Setting to -1 means no timeout. 