### PR TITLE
Added use of set_new_handler

### DIFF
--- a/oss_src/fileio/fixed_size_cache_manager.cpp
+++ b/oss_src/fileio/fixed_size_cache_manager.cpp
@@ -15,6 +15,18 @@
 namespace graphlab {
 
 namespace fileio {
+
+std::new_handler previous_new_handler = nullptr;
+
+void cache_new_handler() {
+  std::set_new_handler(previous_new_handler);
+  // evict everything larger than 1MB
+  // we restore our handler only IF we managed to free something
+  // Otherwise this could be an infinite loop.
+  if (fixed_size_cache_manager::get_instance().force_evict(1024*1024)) {
+    std::set_new_handler(cache_new_handler);
+  }
+}
 /*************************************************************************/
 /*                                                                       */
 /*                         Cache Block implementation                    */
@@ -134,7 +146,10 @@ namespace fileio {
    return *instance;
  }
 
-  fixed_size_cache_manager::fixed_size_cache_manager() { }
+  fixed_size_cache_manager::fixed_size_cache_manager() {
+    previous_new_handler = std::get_new_handler();
+    std::set_new_handler(cache_new_handler);
+  }
 
   fixed_size_cache_manager::~fixed_size_cache_manager() {
     clear();
@@ -145,7 +160,7 @@ namespace fileio {
   }
 
  EXPORT cache_id_type fixed_size_cache_manager::get_temp_cache_id(std::string suffix) {
-    std::lock_guard<graphlab::mutex> scoped_lock(mutex);
+    std::lock_guard<graphlab::recursive_mutex> scoped_lock(mutex);
     std::stringstream ss;
     ss << std::setfill('0') << std::setw(6) << temp_cache_counter;
     ++temp_cache_counter;
@@ -154,7 +169,7 @@ namespace fileio {
   }
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::new_cache(cache_id_type cache_id) {
-    std::lock_guard<graphlab::mutex> lck(mutex);
+    std::lock_guard<graphlab::recursive_mutex> lck(mutex);
     logstream_ontick(5, LOG_INFO) << "Cache Utilization:" << get_cache_utilization() << std::endl;
     // if we have exceeded, we try to evict
     if (current_cache_utilization.value >= FILEIO_MAXIMUM_CACHE_CAPACITY) try_cache_evict();
@@ -195,7 +210,7 @@ namespace fileio {
 
   void fixed_size_cache_manager::free(std::shared_ptr<cache_block> block) {
     logstream(LOG_DEBUG) << "Free cache block " << block->cache_id << std::endl;
-    std::lock_guard<graphlab::mutex> lck(mutex);
+    std::lock_guard<graphlab::recursive_mutex> lck(mutex);
     cache_id_type id = block->cache_id;
     auto iter = cache_blocks.find(id);
     ASSERT_TRUE(iter != cache_blocks.end());
@@ -204,7 +219,7 @@ namespace fileio {
 
   std::shared_ptr<cache_block> fixed_size_cache_manager::get_cache(cache_id_type cache_id) {
     logstream(LOG_DEBUG) << "Get cache block " << cache_id << std::endl;
-    std::lock_guard<graphlab::mutex> lck(mutex);
+    std::lock_guard<graphlab::recursive_mutex> lck(mutex);
     if (cache_blocks.find(cache_id) != cache_blocks.end()) {
       return cache_blocks[cache_id];
     }
@@ -217,6 +232,25 @@ namespace fileio {
 
   void fixed_size_cache_manager::decrement_utilization(ssize_t increment) {
     current_cache_utilization.dec(increment);
+  }
+
+  bool fixed_size_cache_manager::force_evict(size_t minimum_size) {
+    bool freed_stuff = false;
+    std::lock_guard<graphlab::recursive_mutex> lck(mutex);
+    for (auto& iter: cache_blocks) {
+      // we can only evict if we are the only pointers to the cache block
+      if (iter.second.unique() && iter.second->is_pointer()) {
+        if (iter.second->get_pointer_size() >= minimum_size) {
+          logstream(LOG_INFO) << "Evicting " << iter.first
+                              << " with size " << iter.second->get_pointer_size() << std::endl;
+          iter.second->write_to_file();
+          freed_stuff = true;
+        }
+      }
+    }
+    logstream(LOG_INFO) << "Cache Utilization:" << get_cache_utilization()
+                        << std::endl;
+    return freed_stuff;
   }
 
   void fixed_size_cache_manager::try_cache_evict() {

--- a/oss_src/fileio/fixed_size_cache_manager.hpp
+++ b/oss_src/fileio/fixed_size_cache_manager.hpp
@@ -231,6 +231,12 @@ class fixed_size_cache_manager {
   void free(std::shared_ptr<cache_block> block);
 
   /**
+   * Forces to evict all blocks larger than a certain size.
+   * Returns true if blocks were evicted and false otherwise.
+   */
+  bool force_evict(size_t minimum_size);
+
+  /**
    * Clear all cache blocks in the manager. Reset to initial state.
    */
   void clear();
@@ -258,7 +264,10 @@ class fixed_size_cache_manager {
 
   atomic<size_t> current_cache_utilization;
 
-  graphlab::mutex mutex;
+  // this is a recursive mutex due to the use of std::new_handler
+  // An allocation failure can happen anytime; perhaps even while a
+  // lock was acquired by the same thread.
+  graphlab::recursive_mutex mutex;
   std::unordered_map<std::string, std::shared_ptr<cache_block> > cache_blocks;
 
   /**

--- a/oss_test/fileio/fixed_size_cache_manager_test.cxx
+++ b/oss_test/fileio/fixed_size_cache_manager_test.cxx
@@ -125,6 +125,7 @@ class cache_eviction_test: public CxxTest::TestSuite {
  public:
   void test_cache_eviction_mechanism() {
     // set cache cap to 64K
+    global_logger().set_log_level(LOG_INFO);
     auto& cache_instance = fixed_size_cache_manager::get_instance();
     graphlab::fileio::FILEIO_MAXIMUM_CACHE_CAPACITY = 64*1024;
     graphlab::fileio::FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE = 32*1024;
@@ -167,5 +168,18 @@ class cache_eviction_test: public CxxTest::TestSuite {
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[4*1024])->is_pointer(), true);
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[2*1024])->is_pointer(), true);
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[1*1024])->is_pointer(), true);
+    fin.close();
+    TS_ASSERT_EQUALS(cache_instance.force_evict(16*1024), true);
+    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[16*1024])->is_pointer(), false);
+    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[8*1024])->is_pointer(), true);
+    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[4*1024])->is_pointer(), true);
+    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[2*1024])->is_pointer(), true);
+    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[1*1024])->is_pointer(), true);
+    TS_ASSERT_EQUALS(cache_instance.force_evict(16*1024), false);
+
+    // cleanup
+    for (auto i : size_to_file) {
+      graphlab::fileio::delete_path(i.second);
+    }
   }
 };


### PR DESCRIPTION
See http://en.cppreference.com/w/cpp/memory/new/set_new_handler

If a memory allocation failure occurs, we get a chance to flush caches to
free up enough memory so that the allocation may succeed after that.