### PR TITLE
Lambda worker tcp forced fallback because a hypersquirrel says so

### DIFF
--- a/oss_src/fault/CMakeLists.txt
+++ b/oss_src/fault/CMakeLists.txt
@@ -23,6 +23,7 @@ make_library(fault_comm
   util
   parallel
   logger
+  globals
 )
 set_property(TARGET fault_comm APPEND PROPERTY COMPILE_DEFINITIONS FAKE_ZOOKEEPER) 
 
@@ -50,6 +51,7 @@ make_library(fault_comm_zookeeper
   util
   parallel
   logger
+  globals
 )
 else()
   make_empty_library(fault_comm_zookeeper fault_comm)

--- a/oss_src/fault/sockets/socket_config.hpp
+++ b/oss_src/fault/sockets/socket_config.hpp
@@ -17,6 +17,8 @@ void set_recv_timeout(int ms);
 
 void set_conservative_socket_parameters(void* socket);
 
+extern int64_t FORCE_IPC_TO_TCP_FALLBACK;
+
 /**
  * Normalizes an zeromq address. 
  * On windows, this converts IPc addresses to localhost address.

--- a/oss_src/lambda/CMakeLists.txt
+++ b/oss_src/lambda/CMakeLists.txt
@@ -2,6 +2,7 @@ project(lambda)
 
 make_library(pylambda
   SOURCES
+    worker_pool.cpp
     lambda_constants.cpp
     lambda_master.cpp
     pylambda_function.cpp

--- a/oss_src/lambda/worker_pool.cpp
+++ b/oss_src/lambda/worker_pool.cpp
@@ -1,0 +1,16 @@
+#include <globals/globals.hpp>
+#include <export.hpp>
+
+namespace graphlab {
+
+/** The timeout for connecting to a lambda worker, in seconds. 
+ *
+ *  Set to 0 to attempt one try and exit immediately on failure. 
+ *
+ *  Set to -1 to disable timeout completely. 
+ */
+EXPORT double LAMBDA_WORKER_CONNECTION_TIMEOUT = 60;
+
+REGISTER_GLOBAL(double, LAMBDA_WORKER_CONNECTION_TIMEOUT, true)
+
+}

--- a/oss_test/lambda/dummy_worker.cpp
+++ b/oss_test/lambda/dummy_worker.cpp
@@ -17,6 +17,7 @@
 #include <cppipc/cppipc.hpp>
 #include <process/process_util.hpp>
 #include "dummy_worker_interface.hpp"
+#include <fault/sockets/socket_config.hpp>
 #include <thread>
 
 using namespace graphlab;
@@ -39,6 +40,13 @@ int main(int argc, char** argv) {
     std::cerr << "Usage: ./dummy_worker ipc:///tmp/test_address" << std::endl;
     exit(1);
   }
+
+  // Manually set this one.
+  char* use_fallback = std::getenv("GRAPHLAB_FORCE_IPC_TO_TCP_FALLBACK");
+  if(use_fallback != nullptr && std::string(use_fallback) == "1") {
+    libfault::FORCE_IPC_TO_TCP_FALLBACK = true;
+  }
+  
   size_t parent_pid = get_parent_pid();
   // Options
   std::string program_name = argv[0];

--- a/oss_test/lambda/worker_pool_test.cxx
+++ b/oss_test/lambda/worker_pool_test.cxx
@@ -19,13 +19,22 @@
 #include <lambda/worker_pool.hpp>
 #include <parallel/lambda_omp.hpp>
 #include <fileio/fs_utils.hpp>
+#include <fault/sockets/socket_config.hpp>
 #include "dummy_worker_interface.hpp"
 
 using namespace graphlab;
 
 class worker_pool_test: public CxxTest::TestSuite {
  public:
-  worker_pool_test() { global_logger().set_log_level(LOG_INFO); }
+  worker_pool_test() {
+    global_logger().set_log_level(LOG_INFO);
+
+    // Manually set this one.
+    char* use_fallback = std::getenv("GRAPHLAB_FORCE_IPC_TO_TCP_FALLBACK");
+    if(use_fallback != nullptr && std::string(use_fallback) == "1") {
+      libfault::FORCE_IPC_TO_TCP_FALLBACK = true;
+    }
+  }
   void test_spawn_workers() {
     auto wk_pool = get_worker_pool(nworkers);
     TS_ASSERT_EQUALS(wk_pool->num_workers(), nworkers);


### PR DESCRIPTION
Added GRAPHLAB_FORCE_IPC_TO_TCP_FALLBACK option
Added an option to force IPC to TCP fallback for all OS, not just
windows.