### PR TITLE
Revert "Added use of set_new_handler"

### DIFF
--- a/oss_src/fileio/fixed_size_cache_manager.hpp
+++ b/oss_src/fileio/fixed_size_cache_manager.hpp
@@ -231,12 +231,6 @@ class fixed_size_cache_manager {
   void free(std::shared_ptr<cache_block> block);
 
   /**
-   * Forces to evict all blocks larger than a certain size.
-   * Returns true if blocks were evicted and false otherwise.
-   */
-  bool force_evict(size_t minimum_size);
-
-  /**
    * Clear all cache blocks in the manager. Reset to initial state.
    */
   void clear();
@@ -264,10 +258,7 @@ class fixed_size_cache_manager {
 
   atomic<size_t> current_cache_utilization;
 
-  // this is a recursive mutex due to the use of std::new_handler
-  // An allocation failure can happen anytime; perhaps even while a
-  // lock was acquired by the same thread.
-  graphlab::recursive_mutex mutex;
+  graphlab::mutex mutex;
   std::unordered_map<std::string, std::shared_ptr<cache_block> > cache_blocks;
 
   /**

--- a/oss_test/fileio/fixed_size_cache_manager_test.cxx
+++ b/oss_test/fileio/fixed_size_cache_manager_test.cxx
@@ -125,7 +125,6 @@ class cache_eviction_test: public CxxTest::TestSuite {
  public:
   void test_cache_eviction_mechanism() {
     // set cache cap to 64K
-    global_logger().set_log_level(LOG_INFO);
     auto& cache_instance = fixed_size_cache_manager::get_instance();
     graphlab::fileio::FILEIO_MAXIMUM_CACHE_CAPACITY = 64*1024;
     graphlab::fileio::FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE = 32*1024;
@@ -168,18 +167,5 @@ class cache_eviction_test: public CxxTest::TestSuite {
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[4*1024])->is_pointer(), true);
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[2*1024])->is_pointer(), true);
     TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[1*1024])->is_pointer(), true);
-    fin.close();
-    TS_ASSERT_EQUALS(cache_instance.force_evict(16*1024), true);
-    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[16*1024])->is_pointer(), false);
-    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[8*1024])->is_pointer(), true);
-    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[4*1024])->is_pointer(), true);
-    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[2*1024])->is_pointer(), true);
-    TS_ASSERT_EQUALS(cache_instance.get_cache(size_to_file[1*1024])->is_pointer(), true);
-    TS_ASSERT_EQUALS(cache_instance.force_evict(16*1024), false);
-
-    // cleanup
-    for (auto i : size_to_file) {
-      graphlab::fileio::delete_path(i.second);
-    }
   }
 };


### PR DESCRIPTION
Reverts dato-code/SFrame#311

This should not have worked. 
https://github.com/dato-code/SFrame/pull/311/files#diff-0d9c5131cf9be17dedddfe3a5cef5aacR258
```
ASSERT_FALSE(mutex.try_lock()) 
```
should always fail because this change changed the mutex to a recursive mutex.

We do indeed have tests that trigger the cache eviction behavior so I have no idea how this ever worked. I will investigate this in greater detail later, but for sanity in master, I am reverting this now.