### PR TITLE
Add PHONY targets to SDK makefile

### DIFF
--- a/oss_src/unity/sdk/makefile_deploy
+++ b/oss_src/unity/sdk/makefile_deploy
@@ -1,3 +1,5 @@
+.PHONY: doc clean all
+
 CXX := g++
 CXXFLAGS := -std=c++11 -I . -shared -fPIC
 


### PR DESCRIPTION
Without `.PHONY`, `make` might refuse to build these targets claiming they are up to date. However, these targets are by definition never up to date since they don't have dependencies specified in the Makefile. To be safe they should always rebuild.