### PR TITLE
Fix windows classifier in setup.py

### DIFF
--- a/oss_src/unity/python/setup.py
+++ b/oss_src/unity/python/setup.py
@@ -120,10 +120,7 @@ if __name__ == '__main__':
                          "Operating System :: POSIX :: BSD",
                          "Operating System :: Unix"]
     elif cur_platform.startswith('win'):
-        classifiers += ["Operating System :: Microsoft :: Windows",
-                        "Operating System :: Microsoft :: Windows 7",
-                        "Operating System :: Microsoft :: Windows Server 2008",
-                        "Operating System :: Microsoft :: Windows Vista"]
+        classifiers += ["Operating System :: Microsoft :: Windows"]
     else:
         msg = (
             "Unsupported Platform: '%s'. SFrame is only supported on Windows, Mac OSX, and Linux." % cur_platform


### PR DESCRIPTION
Ported from dato-code/dato-dev@8fb71dac879687b89b0a8f6ca4183b0d9bfd10a6

PyPI now seems to be rejecting classifiers for specific Windows versions
(at least in this format). GraphLab-Create uploaded successfully with
just "Windows" and no version.

Change-Id: I164b88287a3dead45a619d57966d78a2f8d9d82b