### PR TITLE
Clarifed Some Wording

### DIFF
--- a/oss_src/unity/python/sframe/data_structures/sgraph.py
+++ b/oss_src/unity/python/sframe/data_structures/sgraph.py
@@ -181,12 +181,13 @@ class SGraph(object):
     ----------
     vertices : SFrame, optional
         Vertex data. Must include an ID column with the name specified by
-        `vid_field.` Additional columns are treated as vertex attributes.
+        the `vid_field` parameter. Additional columns are treated as vertex
+        attributes.
 
     edges : SFrame, optional
         Edge data. Must include source and destination ID columns as specified
-        by `src_field` and `dst_field`. Additional columns are treated as edge
-        attributes.
+        by `src_field` and `dst_field` parameters. Additional columns are treated
+        as edge attributes.
 
     vid_field : str, optional
         The name of vertex ID column in the `vertices` SFrame.


### PR DESCRIPTION
I originally thought this was a bug. I thought the name of the id column (in the vertices sframe) should be "vid_field", not that it should match the value of the vid_field parameter. Similar issue with the edge sframe. I think this small wording change makes things a lot clearer.